### PR TITLE
Use SmokeInvocationTraceContext as the default trace context.

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/amzn/service-model-swift-code-generate.git",
         "state": {
           "branch": null,
-          "revision": "b7de9a476aaac18b7988ba44eff471713722108d",
-          "version": "2.0.0"
+          "revision": "059bcb3b24d5750c4b1c8ee579d430d0d6e36698",
+          "version": "2.2.0"
         }
       },
       {
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/amzn/smoke-aws-generate.git",
         "state": {
           "branch": null,
-          "revision": "093b112132f9ce26bb4c7263c8226fc3ef61a245",
-          "version": "2.0.1"
+          "revision": "fc48ee0853defd1f1f0a604c353f15b483346f26",
+          "version": "2.1.0"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -26,8 +26,8 @@ let package = Package(
             targets: ["SmokeFrameworkCodeGeneration"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/amzn/smoke-aws-generate.git", from: "2.0.0"),
-        .package(url: "https://github.com/amzn/service-model-swift-code-generate.git", from: "2.0.0"),
+        .package(url: "https://github.com/amzn/smoke-aws-generate.git", from: "2.1.0"),
+        .package(url: "https://github.com/amzn/service-model-swift-code-generate.git", from: "2.2.0"),
     ],
     targets: [
         .target(

--- a/Sources/SmokeFrameworkCodeGeneration/ServiceModelCodeGenerator+generateHandlerSelector.swift
+++ b/Sources/SmokeFrameworkCodeGeneration/ServiceModelCodeGenerator+generateHandlerSelector.swift
@@ -29,12 +29,10 @@ extension ServiceModelCodeGenerator {
         let baseName = applicationDescription.baseName
         let baseFilePath = applicationDescription.baseFilePath
         
+        addGeneratedFileHeader(fileBuilder: fileBuilder)
+        
         // build a map of http url to operation handler
         fileBuilder.appendLine("""
-            // swiftlint:disable superfluous_disable_command
-            // swiftlint:disable file_length line_length identifier_name type_name vertical_parameter_alignment
-            // -- Generated Code; do not edit --
-            //
             // \(baseName)OperationsHanderSelector.swift
             // \(baseName)OperationsHTTP1
             //

--- a/Sources/SmokeFrameworkCodeGeneration/ServiceModelCodeGenerator+generateModelOperationHTTPInput.swift
+++ b/Sources/SmokeFrameworkCodeGeneration/ServiceModelCodeGenerator+generateModelOperationHTTPInput.swift
@@ -32,11 +32,9 @@ public extension ServiceModelCodeGenerator {
             fileBuilder.appendLine(fileHeader)
         }
         
+        addGeneratedFileHeader(fileBuilder: fileBuilder)
+        
         fileBuilder.appendLine("""
-            // swiftlint:disable superfluous_disable_command
-            // swiftlint:disable file_length line_length identifier_name type_name vertical_parameter_alignment
-            // -- Generated Code; do not edit --
-            //
             // \(baseName)OperationsHTTPInput.swift
             // \(baseName)OperationsHTTP1
             //

--- a/Sources/SmokeFrameworkCodeGeneration/ServiceModelCodeGenerator+generateModelOperationHTTPOutput.swift
+++ b/Sources/SmokeFrameworkCodeGeneration/ServiceModelCodeGenerator+generateModelOperationHTTPOutput.swift
@@ -33,11 +33,9 @@ public extension ServiceModelCodeGenerator {
             fileBuilder.appendLine(fileHeader)
         }
         
+        addGeneratedFileHeader(fileBuilder: fileBuilder)
+        
         fileBuilder.appendLine("""
-            // swiftlint:disable superfluous_disable_command
-            // swiftlint:disable file_length line_length identifier_name type_name vertical_parameter_alignment
-            // -- Generated Code; do not edit --
-            //
             // \(baseName)OperationsHTTPOutput.swift
             // \(baseName)OperationsHTTP1
             //

--- a/Sources/SmokeFrameworkCodeGeneration/SmokeFrameworkCodeGeneration.swift
+++ b/Sources/SmokeFrameworkCodeGeneration/SmokeFrameworkCodeGeneration.swift
@@ -66,7 +66,8 @@ extension ServiceModelCodeGenerator {
             isThrowingMock: true)
         let awsClientDelegate = APIGatewayClientDelegate(
             baseName: applicationDescription.baseName, asyncResultType: nil,
-            contentType: "application/json", signAllHeaders: false)
+            contentType: "application/json", signAllHeaders: false,
+            defaultInvocationTraceContext: InvocationTraceContextDeclaration(name: "SmokeInvocationTraceContext", importPackage: "SmokeOperationsHTTP1"))
         let awsModelErrorsDelegate = SmokeFrameworkModelErrorsDelegate()
         
         generateServerOperationHandlerStubs(generationType: generationType)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Use SmokeInvocationTraceContext as the default trace context.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
