### PR TITLE
Set optionalsInitializeEmpty as true

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/amzn/service-model-swift-code-generate.git",
         "state": {
           "branch": null,
-          "revision": "66044bce312dfaec55377e7ce59bca4c036232fc",
-          "version": "2.3.0"
+          "revision": "b683d232c4e2f576a3b869a3ae1c6583bf4d34d7",
+          "version": "2.3.1"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -27,7 +27,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/amzn/smoke-aws-generate.git", from: "2.1.0"),
-        .package(url: "https://github.com/amzn/service-model-swift-code-generate.git", from: "2.2.0"),
+        .package(url: "https://github.com/amzn/service-model-swift-code-generate.git", from: "2.3.1"),
     ],
     targets: [
         .target(

--- a/Sources/SmokeFrameworkApplicationGenerate/main.swift
+++ b/Sources/SmokeFrameworkApplicationGenerate/main.swift
@@ -182,7 +182,7 @@ private func startCodeGeneration(
         validationErrorDeclaration: validationErrorDeclaration,
         unrecognizedErrorDeclaration: unrecognizedErrorDeclaration,
         generateModelShapeConversions: true,
-        optionalsInitializeEmpty: false,
+        optionalsInitializeEmpty: true,
         fileHeader: nil,
         httpClientConfiguration: httpClientConfiguration)
     


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Set optionalsInitializeEmpty as true. When generating model objects, the generated constructor will provide a default value of `nil` to optional properties. This means optional properties can be added without breaking consuming code.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
