### PR TITLE
Add the ability to control code generation by a config file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,39 +5,27 @@ matrix:
       dist: xenial
       sudo: required
       services: docker
-      env: DOCKER_IMAGE_TAG=swift:5.3.1-bionic ONLY_RUN_SWIFT_LINT=no USE_APT_GET=yes
+      env: DOCKER_IMAGE_TAG=swift:5.3.3-bionic ONLY_RUN_SWIFT_LINT=no USE_APT_GET=yes
     - os: linux
       dist: xenial
       sudo: required
       services: docker
-      env: DOCKER_IMAGE_TAG=swift:5.3.1-xenial ONLY_RUN_SWIFT_LINT=no USE_APT_GET=yes
+      env: DOCKER_IMAGE_TAG=swift:5.3.3-xenial ONLY_RUN_SWIFT_LINT=no USE_APT_GET=yes
     - os: linux
       dist: xenial
       sudo: required
       services: docker
-      env: DOCKER_IMAGE_TAG=swift:5.3.1-focal ONLY_RUN_SWIFT_LINT=no USE_APT_GET=yes
+      env: DOCKER_IMAGE_TAG=swift:5.3.3-focal ONLY_RUN_SWIFT_LINT=no USE_APT_GET=yes
     - os: linux
       dist: xenial
       sudo: required
       services: docker
-      env: DOCKER_IMAGE_TAG=swift:5.3.1-amazonlinux2 ONLY_RUN_SWIFT_LINT=no USE_APT_GET=no
+      env: DOCKER_IMAGE_TAG=swift:5.3.3-amazonlinux2 ONLY_RUN_SWIFT_LINT=no USE_APT_GET=no
     - os: linux
       dist: xenial
       sudo: required
       services: docker
-      env: DOCKER_IMAGE_TAG=swift:5.3.1-centos8 ONLY_RUN_SWIFT_LINT=no USE_APT_GET=no
-
-    - os: linux
-      dist: xenial
-      sudo: required
-      services: docker
-      env: DOCKER_IMAGE_TAG=swift:5.2.5-bionic ONLY_RUN_SWIFT_LINT=no USE_APT_GET=yes
-
-    - os: linux
-      dist: xenial
-      sudo: required
-      services: docker
-      env: DOCKER_IMAGE_TAG=swift:5.1-bionic ONLY_RUN_SWIFT_LINT=no USE_APT_GET=yes
+      env: DOCKER_IMAGE_TAG=swift:5.3.3-centos8 ONLY_RUN_SWIFT_LINT=no USE_APT_GET=no
 
     # Use a docker image that contains the SwiftLint executable the verify the code against the linter.
 #    - os: linux

--- a/Package.resolved
+++ b/Package.resolved
@@ -5,18 +5,18 @@
         "package": "ServiceModelSwiftCodeGenerate",
         "repositoryURL": "https://github.com/amzn/service-model-swift-code-generate.git",
         "state": {
-          "branch": null,
-          "revision": "2693c4d851d1359cd62e7d791546a86bf5bde583",
-          "version": "2.4.0"
+          "branch": "main",
+          "revision": "9230f017a1c0132afbc2ff7f1baf90ef9a03768b",
+          "version": null
         }
       },
       {
         "package": "SmokeAWSGenerate",
         "repositoryURL": "https://github.com/amzn/smoke-aws-generate.git",
         "state": {
-          "branch": null,
-          "revision": "fe028dbd8103407dfdd830acb076f6a84522b2de",
-          "version": "2.4.0"
+          "branch": "main",
+          "revision": "ef7a6c6df344f9c4738d6d437687f86334c709c3",
+          "version": null
         }
       },
       {
@@ -29,12 +29,21 @@
         }
       },
       {
+        "package": "swift-argument-parser",
+        "repositoryURL": "https://github.com/apple/swift-argument-parser",
+        "state": {
+          "branch": null,
+          "revision": "831ed5e860a70e745bc1337830af4786b2576881",
+          "version": "0.4.1"
+        }
+      },
+      {
         "package": "Yams",
         "repositoryURL": "https://github.com/jpsim/Yams.git",
         "state": {
           "branch": null,
-          "revision": "6652aa7b793d3c8a075db0614acb575fcaecf457",
-          "version": "0.7.0"
+          "revision": "4ec0a3c5d6a2446667a2b22c8c7d0fc82dd1d3de",
+          "version": "4.0.5"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.0
+// swift-tools-version:5.2
 //
 // Copyright 2019-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
@@ -17,6 +17,9 @@ import PackageDescription
 
 let package = Package(
     name: "SmokeFrameworkApplicationGenerate",
+    platforms: [
+        .macOS(.v10_15), .iOS(.v10)
+    ],
     products: [
         .executable(
             name: "SmokeFrameworkApplicationGenerate",
@@ -26,15 +29,25 @@ let package = Package(
             targets: ["SmokeFrameworkCodeGeneration"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/amzn/smoke-aws-generate.git", from: "2.1.0"),
-        .package(url: "https://github.com/amzn/service-model-swift-code-generate.git", from: "2.3.1"),
+        .package(name: "ServiceModelSwiftCodeGenerate",
+                 url: "https://github.com/amzn/smoke-aws-generate.git", .branch("main")),
+        .package(name: "SmokeAWSGenerate",
+                 url: "https://github.com/amzn/service-model-swift-code-generate.git", .branch("main")),
+        .package(url: "https://github.com/apple/swift-argument-parser", from: "0.3.0"),
     ],
     targets: [
         .target(
-            name: "SmokeFrameworkApplicationGenerate",
-            dependencies: ["SmokeFrameworkCodeGeneration"]),
+            name: "SmokeFrameworkApplicationGenerate", dependencies: [
+                .target(name: "SmokeFrameworkCodeGeneration"),
+                .product(name: "ArgumentParser", package: "swift-argument-parser"),
+            ]
+        ),
         .target(
-            name: "SmokeFrameworkCodeGeneration",
-            dependencies: ["ServiceModelGenerate", "SmokeAWSModelGenerate"]),
-    ]
+            name: "SmokeFrameworkCodeGeneration", dependencies: [
+                .product(name: "ServiceModelGenerate", package: "ServiceModelSwiftCodeGenerate"),
+                .product(name: "SmokeAWSModelGenerate", package: "SmokeAWSGenerate"),
+            ]
+        ),
+    ],
+    swiftLanguageVersions: [.v5]
 )

--- a/README.md
+++ b/README.md
@@ -31,6 +31,39 @@ You will point this code generator to this directory to output the generated cod
 ## Step 3: Create a model describing your service using Swagger 2.0
 
 Follow the [Swagger specification](https://swagger.io/docs/specification/2-0/basic-structure/) to create an API specification for your service.
+Place this file in the directory you have created. The following steps assume you have called this file `Swagger.yaml` but it
+can be called anything you require.
+
+## Step 4: Create a configuration file for the code generator
+
+Create a `smoke-framework-codegen.json` file in the directory you have created with the following content-
+
+```
+{
+  "baseName" : "EmptyExample",
+  "modelFilePath" : "Swagger.yaml",
+  "generationType" : "serverUpdate",
+  "operationStubGenerationRule" : {
+    "mode" : "allFunctionsWithinContext"
+  }
+}
+```
+
+This JSON file can contain the following fields-
+* **modelFilePath**: Specifies the absolute or relative (to the base directory path) file path to the Swagger model. Required.
+* **baseName**: A base name for your service (without the "Service" postfix). Required.
+* **applicationSuffix**: The suffix that is combined with the `baseName` to create the service's executable name. Defaults to `Service`.
+* **generationType**: `server` to generate a new service; `serverUpdate` to preserve changes to existing operation handlers. Required.
+* **applicationDescription**: A description of the application. Optional.
+* **modelOverride**: A set of overrides to apply to the model. Optional.
+* **httpClientConfiguration**: Configuration for the generated http service clients. The schema for this parameOptional.
+* **operationStubGenerationRule**: How operation stubs are generated and expected by the application. It is recommended that new applications use `allFunctionsWithinContext` which will generate operation stubs within extensions of the Context type[1].
+
+The schemas for the `modelOverride` and `httpClientConfiguration` fields can be found here - https://github.com/amzn/service-model-swift-code-generate/blob/main/Sources/ServiceModelEntities/ModelOverride.swift.
+
+An example configuration - including `modelOverride` configuration - can be found here - https://github.com/amzn/smoke-framework-examples/blob/612fd9dca5d8417d2293a203aca4b02672889d12/PersistenceExampleService/smoke-framework-codegen.json.
+
+[1] Existing smoke-framework based applications may have operation handlers that are standalone functions. You can use the `allStandaloneFunctions` value for `operationStubGenerationRule` to continue this style or migrate the operation handlers - either at once or one-by-one - to being functions on the Context type. See the Migration section at the end of this README for more information.
 
 ## Step 4: Run the code generator
 
@@ -38,25 +71,17 @@ From within your checked out copy of this repository, run this command-
 
 ```bash
 swift run -c release SmokeFrameworkApplicationGenerate \
-  --base-file-path <the path to where you want the service to be generated> \
-  --base-name <a base name for your service (without the "Service" postfix)> \
-  --model-path <the path to the Swagger model you created> \
-  --generation-type [server: to generate a new service|serverUpdate: to preserve changes to existing operation handlers]
- [--model-override-path <optionally the path to a json file that specifies various overrides to the model>]
+  --base-file-path <the path to where you want the service to be generated>
 ```
 
-And example command would look like this-
+An example command would look like this-
 
 ```bash
 swift run -c release SmokeFrameworkApplicationGenerate \
-  --base-file-path /Volumes/Workspace/smoke-framework-examples/PersistenceExampleService \
-  --base-name PersistenceExample \
-  --model-path /Volumes/Workspace/smoke-framework-examples/PersistenceExampleService/Swagger.yaml \
-  --generation-type server \
-  --model-override-path /Volumes/Workspace/smoke-framework-examples/PersistenceExampleService/modelOverride.json
+  --base-file-path /Volumes/Workspace/smoke-framework-examples/PersistenceExampleService
 ```
 
-An example service based on the command above can be found [here](https://github.com/amzn/smoke-framework-examples/tree/master/PersistenceExampleService).
+An example service based on the command above can be found [here](https://github.com/amzn/smoke-framework-examples/tree/main/PersistenceExampleService).
 
 # Step 5: Modify the stubbed service generated
 
@@ -78,18 +103,82 @@ The code generator will produce a Swift Package Manager repository with the foll
 ```
 
 The following three sections of the repository provides initial stubs and can be filled out as required for the service.  
-A `generation-type` of `serverUpdate` will not overwrite changes in these sections-
+A `generationType` of `serverUpdate` will not overwrite changes in these sections-
 
 * **(base-name)Operations:** Stub implementations for each operation; should be modified to fullfill the services's logic.
 * **(base-name)OperationsTests:** Stub test implementations for each operation; should be modified to test the services's logic.
 * **(base-name)Service:** Operations context initialization and shutdown code; should be modified to create the context for the current environment.
 
 The following three section contain code generated code to help the service operate but should not be manually modified. 
-A `generation-type` of `serverUpdate` will overwrite changes in these sections-
+A `generationType` of `serverUpdate` will overwrite changes in these sections-
 
 * **(base-name)Client:** APIGateway and mock clients for the service; should not be manually modified.
 * **(base-name)Client:** Input and output structures and types for the service; should not be manually modified.
 * **(base-name)Client:** Operation selection and input/output type handling specific to HTTP1; should not be manually modified.
+
+# Migration to using smoke-framework-codegen.json
+
+## smoke-framework-codegen.json generation
+
+Existing smoke-framework based applications may not have been generated by using a `smoke-framework-codegen.json` file. Moving
+to a single configuration file is intended to simplify the code generation process and to prepare the way for code generation as part
+of the build process.
+
+You can easily generate the configuration file by adding the `--generate-code-gen-config true` flag to the command previously used to generate the service.
+
+```
+swift run -c release SmokeFrameworkApplicationGenerate \
+  --base-file-path <the path to where you want the service to be generated> \
+  --base-name <a base name for your service (without the "Service" postfix)> \
+  --model-path <the path to the Swagger model you created> \
+  --generate-code-gen-config true \
+  --generation-type [server: to generate a new service|serverUpdate: to preserve changes to existing operation handlers]
+ [--model-override-path <optionally the path to a json file that specifies various overrides to the model>]
+```
+
+An example command would look like this-
+
+```
+swift run -c release SmokeFrameworkApplicationGenerate \
+  --base-file-path /Volumes/Workspace/smoke-framework-examples/PersistenceExampleService \
+  --base-name PersistenceExample \
+  --model-path /Volumes/Workspace/smoke-framework-examples/PersistenceExampleService/Swagger.yaml \
+  --generate-code-gen-config true \
+  --generation-type server \
+  --model-override-path /Volumes/Workspace/smoke-framework-examples/PersistenceExampleService/modelOverride.json
+```
+
+The generated `smoke-framework-codegen.json` file will specify an `operationStubGenerationRule` of `allFunctionsWithinContextExceptForSpecifiedStandaloneFunctions`  with all current operations listed under `operationsWithStandaloneFunctions`. The means that by default the migration will require no change to any existing operation handlers
+but any new operations will have handlers generated within extensions of the Context type. 
+
+## Operation stub generation
+
+It is also possible to change where the generated application expects an operation handler to be - either a standalone function or a function
+on the Context type. Migration of operation handlers is entirely optional and can be done if you find this style more convenient.
+
+To *migrate* an existing operation with a standalone handler function to the Context type, remove the operation from the `operationsWithStandaloneFunctions` list and manually move the operation handler function
+to an extension of the Content type, also removing the explicit context parameter to the function.
+
+For example, an existing operation handler-
+
+```
+public func handleGetCustomerDetails(
+        input: EmptyExampleModel.GetCustomerDetailsRequest,
+        context: EmptyExampleOperationsContext) throws -> EmptyExampleModel.CustomerAttributes {
+    ...
+}
+```
+
+would be migrated to-
+
+```
+extension EmptyExampleOperationsContext {
+    public func handleGetCustomerDetails(input: EmptyExampleModel.GetCustomerDetailsRequest) throws
+    -> EmptyExampleModel.CustomerAttributes {
+        ...
+    }
+}
+```
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 <img src="https://travis-ci.com/amzn/smoke-framework-application-generate.svg?branch=master" alt="Build - Master Branch">
 </a>
 <a href="http://swift.org">
-<img src="https://img.shields.io/badge/swift-5.1|5.2|5.3-orange.svg?style=flat" alt="Swift 5.1, 5.2 and 5.3 Tested">
+<img src="https://img.shields.io/badge/swift-5.3-orange.svg?style=flat" alt="Swift 5.3 Tested">
 </a>
 <img src="https://img.shields.io/badge/ubuntu-16.04|18.04|20.04-yellow.svg?style=flat" alt="Ubuntu 16.04, 18.04 and 20.04 Tested">
 <img src="https://img.shields.io/badge/CentOS-8-yellow.svg?style=flat" alt="CentOS 8 Tested">

--- a/Sources/SmokeFrameworkApplicationGenerate/SmokeFrameworkCodeGen.swift
+++ b/Sources/SmokeFrameworkApplicationGenerate/SmokeFrameworkCodeGen.swift
@@ -1,0 +1,18 @@
+//
+//  SmokeFrameworkCodeGen.swift
+//  SmokeFrameworkApplicationGenerate
+//
+
+import SmokeFrameworkCodeGeneration
+import ServiceModelEntities
+
+struct SmokeFrameworkCodeGen: Codable {
+    let modelFilePath: String
+    let baseName: String
+    let applicationSuffix: String?
+    let generationType: GenerationType
+    let applicationDescription: String?
+    let modelOverride: ModelOverride?
+    let httpClientConfiguration: HttpClientConfiguration?
+    let operationStubGenerationRule: OperationStubGenerationRule
+}

--- a/Sources/SmokeFrameworkApplicationGenerate/main.swift
+++ b/Sources/SmokeFrameworkApplicationGenerate/main.swift
@@ -20,59 +20,26 @@ import ServiceModelCodeGeneration
 import ServiceModelEntities
 import SmokeFrameworkCodeGeneration
 import SwaggerServiceModel
+import ArgumentParser
 
-var isUsage = CommandLine.arguments.count == 2 && CommandLine.arguments[1] == "--help"
+private let configFileName = "smoke-framework-codegen.json"
 
-struct Options {
-    static let modelFilePathOption = "--model-path"
-    static let baseNameOption = "--base-name"
-    static let applicationSuffixOption = "--application-suffix"
-    static let baseFilePathOption = "--base-file-path"
-    static let generationTypeOption = "--generation-type"
-    static let applicationDescriptionOption = "--application-description"
-    static let modelOverridePathOption = "--model-override-path"
-    static let httpClientConfigurationPathOption = "--http-client-configuration-path"
+enum ConfigurationProvider<Type> {
+    case provided(Type)
+    case atPath(String)
 }
 
 struct Parameters {
-    var modelFilePath: String?
-    var baseName: String?
-    var applicationSuffix: String = "Service"
-    var baseFilePath: String?
-    var generationType: GenerationType?
+    var modelFilePath: String
+    var baseName: String
+    var applicationSuffix: String?
+    var baseFilePath: String
+    var generationType: GenerationType
     var applicationDescription: String?
-    var modelOverridePath: String?
-    var httpClientConfigurationPath: String?
-}
-
-func printUsage() {
-    let usage = """
-        OVERVIEW: Generate a swift package based on a Swagger Model.
-
-        USAGE: SmokeFrameworkApplicationGenerate [options]
-
-        OPTIONS:
-          --model-path         The file path for the model definition.
-          --base-name          The base name for the generated libraries and executable.
-                               The generate executable will have the name-
-                                 <base-name><application-suffix>.
-                               Libraries for the application will have names-
-                                 <base-name><generator-defined-library-type-name>
-          --application-suffix The suffix for the generated executable [Service].
-          --base-file-path     The file path to place the root of the generated Swift package.
-          --generation-type    What code to generate. (server|serverUpdate)
-          [--application-description]
-                               A description of the application being created.
-          [--model-override-path]
-                               The file path to model override parameters.
-          [--http-client-configuration-path]
-                               The file path to the configuration for the http client.
-                               If not specified, the http client will consider all
-                               known errors as unretryable and all unknown errors as
-                               unretryable.
-        """
-
-    print(usage)
+    var modelOverride: ConfigurationProvider<ModelOverride>?
+    var generateCodeGenConfig: Bool?
+    var httpClientConfiguration: ConfigurationProvider<HttpClientConfiguration>?
+    var operationStubGenerationRule: OperationStubGenerationRule
 }
 
 private func getModelOverride(modelOverridePath: String?) throws -> ModelOverride? {
@@ -81,7 +48,7 @@ private func getModelOverride(modelOverridePath: String?) throws -> ModelOverrid
         let overrideFile = FileHandle(forReadingAtPath: modelOverridePath)
         
         guard let overrideData = overrideFile?.readDataToEndOfFile() else {
-            fatalError("Specified model file '\(modelOverridePath) doesn't exist.'")
+            fatalError("Specified model file '\(modelOverridePath)' doesn't exist.")
         }
         
         modelOverride = try JSONDecoder().decode(ModelOverride.self, from: overrideData)
@@ -92,62 +59,9 @@ private func getModelOverride(modelOverridePath: String?) throws -> ModelOverrid
     return modelOverride
 }
 
-private func updateParametersFromOption(
-        option: String, parameters: inout Parameters,
-        argument: String, errorMessage: inout String?) {
-    switch option {
-    case Options.modelFilePathOption:
-        parameters.modelFilePath = argument
-    case Options.baseNameOption:
-        parameters.baseName = argument
-    case Options.applicationSuffixOption:
-        parameters.applicationSuffix = argument
-    case Options.baseFilePathOption:
-        parameters.baseFilePath = argument
-    case Options.modelOverridePathOption:
-        parameters.modelOverridePath = argument
-    case Options.httpClientConfigurationPathOption:
-        parameters.httpClientConfigurationPath = argument
-    case Options.applicationDescriptionOption:
-        parameters.applicationDescription = argument
-    case Options.generationTypeOption:
-        if let newGenerationType = GenerationType(rawValue: argument.lowercased()) {
-            parameters.generationType = newGenerationType
-        } else {
-            errorMessage = "Unrecognized generation type: \(argument)"
-            
-            break
-        }
-    default:
-        errorMessage = "Unrecognized option: \(option)"
-    }
-}
-
-private func getOptions(missingOptions: inout Set<String>,
-                        parameters: inout Parameters,
-                        errorMessage: inout String?) {
-    var currentOption: String?
-    for argument in CommandLine.arguments.dropFirst() {
-        if currentOption == nil && argument.hasPrefix("--") {
-            currentOption = argument
-            missingOptions.remove(argument)
-        } else if let option = currentOption, !argument.hasPrefix("--") {
-            updateParametersFromOption(option: option, parameters: &parameters,
-                                       argument: argument, errorMessage: &errorMessage)
-            
-            currentOption = nil
-        } else {
-            printUsage()
-            
-            break
-        }
-        
-    }
-}
-
 private func getHttpClientConfiguration(httpClientConfigurationPath: String?) throws
--> HttpClientConfiguration {
-    let httpClientConfiguration: HttpClientConfiguration
+-> HttpClientConfiguration? {
+    let httpClientConfiguration: HttpClientConfiguration?
     if let httpClientConfigurationPath = httpClientConfigurationPath {
         let overrideFile = FileHandle(forReadingAtPath: httpClientConfigurationPath)
         
@@ -158,11 +72,7 @@ private func getHttpClientConfiguration(httpClientConfigurationPath: String?) th
         httpClientConfiguration = try JSONDecoder().decode(HttpClientConfiguration.self,
                                                            from: overrideData)
     } else {
-        httpClientConfiguration = HttpClientConfiguration(
-            retryOnUnknownError: true,
-            knownErrorsDefaultRetryBehavior: .fail,
-            unretriableUnknownErrors: [],
-            retriableUnknownErrors: [])
+        httpClientConfiguration = nil
     }
     
     return httpClientConfiguration
@@ -173,7 +83,8 @@ private func startCodeGeneration(
         baseName: String, baseFilePath: String,
         applicationDescription: String, applicationSuffix: String,
         modelFilePath: String, generationType: GenerationType,
-        modelOverride: ModelOverride?) throws {
+        operationStubGenerationRule: OperationStubGenerationRule,
+        modelOverride: ModelOverride?) throws -> SwaggerServiceModel {
     let validationErrorDeclaration = ErrorDeclaration.external(
         libraryImport: "SmokeOperations",
         errorType: "SmokeOperationsError")
@@ -192,65 +103,247 @@ private func startCodeGeneration(
         applicationDescription: applicationDescription,
         applicationSuffix: applicationSuffix)
     
-    try SmokeFrameworkCodeGeneration.generateFromModel(
+    return try SmokeFrameworkCodeGeneration.generateFromModel(
         modelFilePath: modelFilePath,
         modelType: SwaggerServiceModel.self,
         generationType: generationType,
         customizations: customizations,
         applicationDescription: fullApplicationDescription,
+        operationStubGenerationRule: operationStubGenerationRule,
         modelOverride: modelOverride)
 }
 
-func handleApplication() throws {
-    var errorMessage: String?
-
-    var missingOptions: Set<String> = [Options.modelFilePathOption, Options.baseNameOption,
-                                       Options.baseFilePathOption, Options.generationTypeOption]
-
-    var parameters = Parameters()
-    getOptions(missingOptions: &missingOptions,
-               parameters: &parameters, errorMessage: &errorMessage)
-
-    let modelOverride = try getModelOverride(modelOverridePath: parameters.modelOverridePath)
-
-    let httpClientConfiguration = try getHttpClientConfiguration(
-        httpClientConfigurationPath: parameters.httpClientConfigurationPath)
-
-    // If there is not an application description but there is a basename
-    if parameters.applicationDescription == nil,
-        let baseName = parameters.baseName {
-        parameters.applicationDescription = "The \(baseName)\(parameters.applicationSuffix)."
+func handleApplication(parameters: Parameters) throws {
+    let modelOverride: ModelOverride?
+    switch parameters.modelOverride {
+    case .provided(let provided):
+        modelOverride = provided
+    case .atPath(let modelOverridePath):
+        modelOverride = try getModelOverride(modelOverridePath: modelOverridePath)
+    case .none:
+        modelOverride = nil
     }
+    
+    let httpClientConfigurationOptional: HttpClientConfiguration?
+    switch parameters.httpClientConfiguration {
+    case .provided(let provided):
+        httpClientConfigurationOptional = provided
+    case .atPath(let httpClientConfigurationPath):
+        httpClientConfigurationOptional = try getHttpClientConfiguration(
+            httpClientConfigurationPath: httpClientConfigurationPath)
+    case .none:
+        httpClientConfigurationOptional = nil
+    }
+    
+    let httpClientConfiguration = httpClientConfigurationOptional ?? HttpClientConfiguration(
+        retryOnUnknownError: true,
+        knownErrorsDefaultRetryBehavior: .fail,
+        unretriableUnknownErrors: [],
+        retriableUnknownErrors: [])
+    
+    let applicationSuffix = parameters.applicationSuffix ?? "Service"
 
-    if errorMessage == nil {
-        if let modelFilePath = parameters.modelFilePath,
-            let baseName = parameters.baseName,
-            let baseFilePath = parameters.baseFilePath,
-            let applicationDescription = parameters.applicationDescription,
-            let generationType = parameters.generationType {
-                try startCodeGeneration(
-                    httpClientConfiguration: httpClientConfiguration,
-                    baseName: baseName, baseFilePath: baseFilePath,
-                    applicationDescription: applicationDescription,
-                    applicationSuffix: parameters.applicationSuffix, modelFilePath: modelFilePath,
-                    generationType: generationType, modelOverride: modelOverride)
+    // Construct an application description if there isn't one
+    let applicationDescription: String
+    if let theApplicationDescription = parameters.applicationDescription {
+        applicationDescription = theApplicationDescription
+    } else {
+        applicationDescription = "The \(parameters.baseName)\(applicationSuffix)."
+    }
+    
+    let model = try startCodeGeneration(
+        httpClientConfiguration: httpClientConfiguration,
+        baseName: parameters.baseName, baseFilePath: parameters.baseFilePath,
+        applicationDescription: applicationDescription,
+        applicationSuffix: applicationSuffix, modelFilePath: parameters.modelFilePath,
+        generationType: parameters.generationType, operationStubGenerationRule: parameters.operationStubGenerationRule,
+        modelOverride: modelOverride)
+    
+    if (parameters.generateCodeGenConfig ?? false) {
+        let parameterModelFilePath = parameters.modelFilePath
+        let parameterModelFilePathWithSeperator = parameters.baseFilePath + "/"
+        
+        let modelFilePath: String
+        if parameterModelFilePath.starts(with: parameterModelFilePathWithSeperator) {
+            modelFilePath = String(parameterModelFilePath.dropFirst(parameterModelFilePathWithSeperator.count))
+        } else if parameterModelFilePath.starts(with: parameterModelFilePath) {
+            modelFilePath = String(parameterModelFilePath.dropFirst(parameterModelFilePath.count))
         } else {
-            var missingOptionsString: String = ""
-            missingOptions.forEach { option in missingOptionsString += " " + option }
-
-            errorMessage = "Missing required options:" + missingOptionsString
+            modelFilePath = parameterModelFilePath
         }
-    }
-
-    if let errorMessage = errorMessage {
-        print("ERROR: \(errorMessage)\n")
-
-        printUsage()
+        
+        let existingOperations = Array(model.operationDescriptions.keys)
+        
+        let smokeFrameworkCodeGen = SmokeFrameworkCodeGen(modelFilePath: modelFilePath,
+                                                          baseName: parameters.baseName,
+                                                          applicationSuffix: parameters.applicationSuffix,
+                                                          generationType: .serverUpdate,
+                                                          applicationDescription: parameters.applicationDescription,
+                                                          modelOverride: modelOverride,
+                                                          httpClientConfiguration: httpClientConfigurationOptional,
+                                                          operationStubGenerationRule: .allFunctionsWithinContextExceptStandaloneFunctionsFor(existingOperations))
+        
+        let jsonEncoder = JSONEncoder()
+        jsonEncoder.outputFormatting = .prettyPrinted
+        
+        let data = try jsonEncoder.encode(smokeFrameworkCodeGen)
+        
+        try data.write(to: URL.init(fileURLWithPath: "\(parameters.baseFilePath)/\(configFileName)"))
     }
 }
 
-if isUsage {
-    printUsage()
-} else {
-    try handleApplication()
+enum SmokeFrameworkApplicationGenerateCommandError: Error {
+    case missingParameter(reason: String)
 }
+
+struct SmokeFrameworkApplicationGenerateCommand: ParsableCommand {
+    static var configuration: CommandConfiguration {
+        return CommandConfiguration(
+            commandName: "SmokeFrameworkApplicationGenerate",
+            abstract: "Code generator for smoke-framework based applications."
+        )
+    }
+    
+    @Option(name: .customLong("model-path"), help: "The file path for the model definition.")
+    var modelFilePath: String?
+    
+    @Option(name: .customLong("base-name"), help: """
+        The base name for the generated libraries and executable.
+        The generate executable will have the name-
+          <base-name><application-suffix>.
+        Libraries for the application will have names-
+          <base-name><generator-defined-library-type-name>
+        """)
+    var baseName: String?
+    
+    @Option(name: .customLong("application-suffix"), help: "The suffix for the generated executable. [Service]")
+    var applicationSuffix: String?
+    
+    @Option(name: .customLong("base-file-path"), help: "The file path to place the root of the generated Swift package.")
+    var baseFilePath: String
+    
+    @Option(name: .customLong("generation-type"), help: "What code to generate. (server|serverUpdate)")
+    var generationType: GenerationType?
+    
+    @Option(name: .customLong("application-description"), help: "A description of the application being created.")
+    var applicationDescription: String?
+    
+    @Option(name: .customLong("model-override-path"), help: "The file path to model override parameters.")
+    var modelOverridePath: String?
+    
+    @Option(name: .customLong("generate-code-gen-config"), help: "The file path to model override parameters.")
+    var generateCodeGenConfig: Bool?
+    
+    @Option(name: .customLong("http-client-configuration-path"), help: """
+         The file path to the configuration for the http client.
+         If not specified, the http client will consider all
+         known errors as unretryable and all unknown errors as
+         unretryable.
+        """)
+    var httpClientConfigurationPath: String?
+
+    mutating func run() throws {
+        let configFile = FileHandle(forReadingAtPath: "\(baseFilePath)/\(configFileName)")
+        
+        let config: SmokeFrameworkCodeGen?
+        if let configData = configFile?.readDataToEndOfFile() {
+            config = try JSONDecoder().decode(SmokeFrameworkCodeGen.self, from: configData)
+        } else {
+            config = nil
+        }
+        
+        let theModelFilePath: String
+        if let modelFilePathOverride = modelFilePath {
+            theModelFilePath = modelFilePathOverride
+        } else if let modelFilePathFromConfig = config?.modelFilePath {
+            // config specified an absolute path
+            if modelFilePathFromConfig.starts(with: "/") {
+                theModelFilePath = modelFilePathFromConfig
+            } else {
+                theModelFilePath = "\(baseFilePath)/\(modelFilePathFromConfig)"
+            }
+        } else {
+            throw SmokeFrameworkApplicationGenerateCommandError.missingParameter(
+                reason: "The model file path needs to be specified either in <base-path>/\(configFileName) or provided directly.")
+        }
+        
+        let theBaseName: String
+        if let baseNameOverride = baseName {
+            theBaseName = baseNameOverride
+        } else if let baseNameFromConfig = config?.baseName {
+            theBaseName = baseNameFromConfig
+        } else {
+            throw SmokeFrameworkApplicationGenerateCommandError.missingParameter(
+                reason: "The base name needs to be specified either in <base-path>/\(configFileName) or provided directly.")
+        }
+        
+        let theApplicationSuffix: String?
+        if let applicationSuffixOverride = applicationSuffix {
+            theApplicationSuffix = applicationSuffixOverride
+        } else if let applicationSuffixFromConfig = config?.applicationSuffix {
+            theApplicationSuffix = applicationSuffixFromConfig
+        } else {
+            theApplicationSuffix = nil
+        }
+        
+        let theGenerationType: GenerationType
+        if let generationTypeOverride = generationType {
+            theGenerationType = generationTypeOverride
+        } else if let generationTypeFromConfig = config?.generationType {
+            theGenerationType = generationTypeFromConfig
+        } else {
+            throw SmokeFrameworkApplicationGenerateCommandError.missingParameter(
+                reason: "The generation type needs to be specified either in <base-path>/\(configFileName) or provided directly.")
+        }
+        
+        let theApplicationDescription: String?
+        if let applicationDescriptionOverride = applicationDescription {
+            theApplicationDescription = applicationDescriptionOverride
+        } else if let applicationDescriptionFromConfig = config?.applicationDescription {
+            theApplicationDescription = applicationDescriptionFromConfig
+        } else {
+            theApplicationDescription = nil
+        }
+        
+        let modelOverride: ConfigurationProvider<ModelOverride>?
+        if let modelOverridePath = modelOverridePath {
+            modelOverride = .atPath(modelOverridePath)
+        } else if let modelOverrideFromConfig = config?.modelOverride {
+            modelOverride = .provided(modelOverrideFromConfig)
+        } else {
+            modelOverride = nil
+        }
+
+        let httpClientConfiguration: ConfigurationProvider<HttpClientConfiguration>?
+        if let httpClientConfigurationPath = httpClientConfigurationPath {
+            httpClientConfiguration = .atPath(httpClientConfigurationPath)
+        } else if let httpClientConfigurationFromConfig = config?.httpClientConfiguration {
+            httpClientConfiguration = .provided(httpClientConfigurationFromConfig)
+        } else {
+            httpClientConfiguration = nil
+        }
+        
+        let operationStubGenerationRule: OperationStubGenerationRule
+        if let operationStubGenerationRuleFromConfig = config?.operationStubGenerationRule {
+            operationStubGenerationRule = operationStubGenerationRuleFromConfig
+        } else {
+            operationStubGenerationRule = .allStandaloneFunctions
+        }
+        
+        let parameters = Parameters(
+            modelFilePath: theModelFilePath,
+            baseName: theBaseName,
+            applicationSuffix: theApplicationSuffix,
+            baseFilePath: baseFilePath,
+            generationType: theGenerationType,
+            applicationDescription: theApplicationDescription,
+            modelOverride: modelOverride,
+            generateCodeGenConfig: generateCodeGenConfig ?? false,
+            httpClientConfiguration: httpClientConfiguration,
+            operationStubGenerationRule: operationStubGenerationRule)
+        
+        try handleApplication(parameters: parameters)
+    }
+}
+
+SmokeFrameworkApplicationGenerateCommand.main()

--- a/Sources/SmokeFrameworkCodeGeneration/ServiceModelCodeGenerator+generateServerApplicationFiles.swift
+++ b/Sources/SmokeFrameworkCodeGeneration/ServiceModelCodeGenerator+generateServerApplicationFiles.swift
@@ -106,7 +106,7 @@ extension ServiceModelCodeGenerator {
                         targets: ["\(baseName)\(applicationSuffix)"]),
                     ],
                 dependencies: [
-                    .package(url: "https://github.com/amzn/smoke-framework.git", from: "2.0.0"),
+                    .package(url: "https://github.com/amzn/smoke-framework.git", from: "2.7.0"),
                     .package(url: "https://github.com/amzn/smoke-aws-credentials.git", from: "2.0.0"),
                     .package(url: "https://github.com/amzn/smoke-aws.git", from: "2.0.0"),
                     .package(url: "https://github.com/apple/swift-log.git", from: "1.0.0"),

--- a/Sources/SmokeFrameworkCodeGeneration/SmokeFrameworkCodeGeneration.swift
+++ b/Sources/SmokeFrameworkCodeGeneration/SmokeFrameworkCodeGeneration.swift
@@ -43,7 +43,8 @@ public enum OperationStubGenerationRule: Codable {
     
     enum CodingKeys: String, CodingKey {
         case mode
-        case exceptions
+        case operationsWithStandaloneFunctions
+        case operationsWithFunctionsWithinContext
     }
     
     enum Mode: String, Codable {
@@ -89,10 +90,10 @@ public enum OperationStubGenerationRule: Codable {
         case .allStandaloneFunctions:
             self = .allStandaloneFunctions
         case .allFunctionsWithinContextExceptForSpecifiedStandaloneFunctions:
-            let exceptions = try values.decode([String].self, forKey: .exceptions)
+            let exceptions = try values.decode([String].self, forKey: .operationsWithStandaloneFunctions)
             self = .allFunctionsWithinContextExceptStandaloneFunctionsFor(exceptions)
         case .allStandaloneFunctionsExceptForSpecifiedFunctionsWithinContext:
-            let exceptions = try values.decode([String].self, forKey: .exceptions)
+            let exceptions = try values.decode([String].self, forKey: .operationsWithFunctionsWithinContext)
             self = .allStandaloneFunctionsExceptFunctionsWithinContextFor(exceptions)
         }
     }
@@ -103,9 +104,9 @@ public enum OperationStubGenerationRule: Codable {
         
         switch self {
         case .allFunctionsWithinContextExceptStandaloneFunctionsFor(let whitelist):
-            try container.encode(whitelist, forKey: .exceptions)
+            try container.encode(whitelist, forKey: .operationsWithStandaloneFunctions)
         case .allStandaloneFunctionsExceptFunctionsWithinContextFor(let whitelist):
-            try container.encode(whitelist, forKey: .exceptions)
+            try container.encode(whitelist, forKey: .operationsWithFunctionsWithinContext)
         case .allFunctionsWithinContext, .allStandaloneFunctions:
             break
         }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
1. Use swift-argument-parser for argument parsing; use updated dependencies that will be eventually become 3.x.x.
2. Add the ability to use a config file - `smoke-framework-codegen.json` in the base directory - to specify arguments to the parser
3. Allow the configuration file to specify on an operation-by-operation basis if the handler function remains a stand-alone function or is specified as a function on the context type.
4. Provide an option to generate the new config file from an existing code generation command
5. Update the README to detail the new changes
6. This config file will ultimately be useful when we can incorporate code generation as part of the build process (https://github.com/apple/swift-evolution/blob/main/proposals/0303-swiftpm-extensible-build-tools.md) 

I have updated the smoke-framework-examples repository with a branch showing these changes-
https://github.com/amzn/smoke-framework-examples/tree/operation_handlers_on_context/PersistenceExampleService


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
