### PR TITLE
Add streamlined initializer option.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,37 +2,22 @@
 matrix:
   include:
     - os: linux
-      dist: xenial
+      dist: bionic
       sudo: required
       services: docker
-      env: DOCKER_IMAGE_TAG=swift:5.3.3-bionic ONLY_RUN_SWIFT_LINT=no USE_APT_GET=yes
+      env: DOCKER_IMAGE_TAG=swift:5.4.0-amazonlinux2 ONLY_RUN_SWIFT_LINT=no USE_APT_GET=no
+
     - os: linux
-      dist: xenial
-      sudo: required
-      services: docker
-      env: DOCKER_IMAGE_TAG=swift:5.3.3-xenial ONLY_RUN_SWIFT_LINT=no USE_APT_GET=yes
-    - os: linux
-      dist: xenial
-      sudo: required
-      services: docker
-      env: DOCKER_IMAGE_TAG=swift:5.3.3-focal ONLY_RUN_SWIFT_LINT=no USE_APT_GET=yes
-    - os: linux
-      dist: xenial
+      dist: bionic
       sudo: required
       services: docker
       env: DOCKER_IMAGE_TAG=swift:5.3.3-amazonlinux2 ONLY_RUN_SWIFT_LINT=no USE_APT_GET=no
+
     - os: linux
-      dist: xenial
+      dist: bionic
       sudo: required
       services: docker
-      env: DOCKER_IMAGE_TAG=swift:5.3.3-centos8 ONLY_RUN_SWIFT_LINT=no USE_APT_GET=no
-
-    # Use a docker image that contains the SwiftLint executable the verify the code against the linter.
-#    - os: linux
-#      dist: xenial
-#      sudo: required
-#      services: docker
-#      env: DOCKER_IMAGE_TAG=bytesguy/swiftlint:0.39.2 ONLY_RUN_SWIFT_LINT=yes USE_APT_GET=no
+      env: DOCKER_IMAGE_TAG=swift:5.2.5-amazonlinux2 ONLY_RUN_SWIFT_LINT=no USE_APT_GET=no
 
 before_install:
   - docker pull $DOCKER_IMAGE_TAG

--- a/Package.resolved
+++ b/Package.resolved
@@ -6,7 +6,7 @@
         "repositoryURL": "https://github.com/amzn/service-model-swift-code-generate.git",
         "state": {
           "branch": "main",
-          "revision": "9230f017a1c0132afbc2ff7f1baf90ef9a03768b",
+          "revision": "56271351b198112669f811c4eec8909c833bb65b",
           "version": null
         }
       },
@@ -15,7 +15,7 @@
         "repositoryURL": "https://github.com/amzn/smoke-aws-generate.git",
         "state": {
           "branch": "main",
-          "revision": "ef7a6c6df344f9c4738d6d437687f86334c709c3",
+          "revision": "cec8913ff0a952723ac089490eb3c79a946dc331",
           "version": null
         }
       },
@@ -33,8 +33,8 @@
         "repositoryURL": "https://github.com/apple/swift-argument-parser",
         "state": {
           "branch": null,
-          "revision": "831ed5e860a70e745bc1337830af4786b2576881",
-          "version": "0.4.1"
+          "revision": "986d191f94cec88f6350056da59c2e59e83d1229",
+          "version": "0.4.3"
         }
       },
       {
@@ -42,8 +42,8 @@
         "repositoryURL": "https://github.com/jpsim/Yams.git",
         "state": {
           "branch": null,
-          "revision": "4ec0a3c5d6a2446667a2b22c8c7d0fc82dd1d3de",
-          "version": "4.0.5"
+          "revision": "9ff1cc9327586db4e0c8f46f064b6a82ec1566fa",
+          "version": "4.0.6"
         }
       }
     ]

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 <img src="https://travis-ci.com/amzn/smoke-framework-application-generate.svg?branch=master" alt="Build - Master Branch">
 </a>
 <a href="http://swift.org">
-<img src="https://img.shields.io/badge/swift-5.3-orange.svg?style=flat" alt="Swift 5.3 Tested">
+<img src="https://img.shields.io/badge/swift-5.2|5.3|5.4-orange.svg?style=flat" alt="Swift 5.2, 5.3 and 5.4 Tested">
 </a>
 <img src="https://img.shields.io/badge/ubuntu-16.04|18.04|20.04-yellow.svg?style=flat" alt="Ubuntu 16.04, 18.04 and 20.04 Tested">
 <img src="https://img.shields.io/badge/CentOS-8-yellow.svg?style=flat" alt="CentOS 8 Tested">

--- a/Sources/SmokeFrameworkApplicationGenerate/SmokeFrameworkCodeGen.swift
+++ b/Sources/SmokeFrameworkApplicationGenerate/SmokeFrameworkCodeGen.swift
@@ -5,6 +5,7 @@
 
 import SmokeFrameworkCodeGeneration
 import ServiceModelEntities
+import ServiceModelCodeGeneration
 
 struct SmokeFrameworkCodeGen: Codable {
     let modelFilePath: String
@@ -14,5 +15,6 @@ struct SmokeFrameworkCodeGen: Codable {
     let applicationDescription: String?
     let modelOverride: ModelOverride?
     let httpClientConfiguration: HttpClientConfiguration?
+    let initializationType: InitializationType?
     let operationStubGenerationRule: OperationStubGenerationRule
 }

--- a/Sources/SmokeFrameworkApplicationGenerate/main.swift
+++ b/Sources/SmokeFrameworkApplicationGenerate/main.swift
@@ -39,6 +39,7 @@ struct Parameters {
     var modelOverride: ConfigurationProvider<ModelOverride>?
     var generateCodeGenConfig: Bool?
     var httpClientConfiguration: ConfigurationProvider<HttpClientConfiguration>?
+    var initializationType: InitializationType?
     var operationStubGenerationRule: OperationStubGenerationRule
 }
 
@@ -83,6 +84,7 @@ private func startCodeGeneration(
         baseName: String, baseFilePath: String,
         applicationDescription: String, applicationSuffix: String,
         modelFilePath: String, generationType: GenerationType,
+        initializationType: InitializationType,
         operationStubGenerationRule: OperationStubGenerationRule,
         modelOverride: ModelOverride?) throws -> SwaggerServiceModel {
     let validationErrorDeclaration = ErrorDeclaration.external(
@@ -92,6 +94,7 @@ private func startCodeGeneration(
     let customizations = CodeGenerationCustomizations(
         validationErrorDeclaration: validationErrorDeclaration,
         unrecognizedErrorDeclaration: unrecognizedErrorDeclaration,
+        asyncAwaitGeneration: .none,
         generateModelShapeConversions: true,
         optionalsInitializeEmpty: true,
         fileHeader: nil,
@@ -110,6 +113,7 @@ private func startCodeGeneration(
         customizations: customizations,
         applicationDescription: fullApplicationDescription,
         operationStubGenerationRule: operationStubGenerationRule,
+        initializationType: initializationType,
         modelOverride: modelOverride)
 }
 
@@ -156,7 +160,9 @@ func handleApplication(parameters: Parameters) throws {
         baseName: parameters.baseName, baseFilePath: parameters.baseFilePath,
         applicationDescription: applicationDescription,
         applicationSuffix: applicationSuffix, modelFilePath: parameters.modelFilePath,
-        generationType: parameters.generationType, operationStubGenerationRule: parameters.operationStubGenerationRule,
+        generationType: parameters.generationType,
+        initializationType: parameters.initializationType ?? .original,
+        operationStubGenerationRule: parameters.operationStubGenerationRule,
         modelOverride: modelOverride)
     
     if (parameters.generateCodeGenConfig ?? false) {
@@ -181,6 +187,7 @@ func handleApplication(parameters: Parameters) throws {
                                                           applicationDescription: parameters.applicationDescription,
                                                           modelOverride: modelOverride,
                                                           httpClientConfiguration: httpClientConfigurationOptional,
+                                                          initializationType: parameters.initializationType,
                                                           operationStubGenerationRule: .allFunctionsWithinContextExceptStandaloneFunctionsFor(existingOperations))
         
         let jsonEncoder = JSONEncoder()
@@ -340,6 +347,7 @@ struct SmokeFrameworkApplicationGenerateCommand: ParsableCommand {
             modelOverride: modelOverride,
             generateCodeGenConfig: generateCodeGenConfig ?? false,
             httpClientConfiguration: httpClientConfiguration,
+            initializationType: config?.initializationType,
             operationStubGenerationRule: operationStubGenerationRule)
         
         try handleApplication(parameters: parameters)

--- a/Sources/SmokeFrameworkCodeGeneration/ServiceModelCodeGenerator+generateServerOperationStubs.swift
+++ b/Sources/SmokeFrameworkCodeGeneration/ServiceModelCodeGenerator+generateServerOperationStubs.swift
@@ -170,7 +170,9 @@ extension ServiceModelCodeGenerator {
             errors = " throws"
             var description = " - Throws: "
             
-            for (index, error) in operationDescription.errors.enumerated() {
+            let sortedErrors = operationDescription.errors.sorted(by: <)
+            
+            for (index, error) in sortedErrors.enumerated() {
                 if index != 0 {
                     description += ", "
                 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Adds an option to the `smoke-framework-codegen.json` configuration file-

```
"initializationType": "STREAMLINED"
```

That provides a streamlined initialiser where all initialisation boilerplate is abstracted behind a code-generated initialiser protocol. This leaves the initialiser implementation to just be the application initialisation logic-

https://github.com/amzn/smoke-framework-examples/blob/streamlined_initializer/PersistenceExampleService/Sources/PersistenceExampleService/PersistenceExamplePerInvocationContextInitializer.swift


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
