### PR TITLE
Fix missing SmokeAsyncHTTP import for operation handler selector

### DIFF
--- a/Sources/SmokeFrameworkCodeGeneration/ServiceModelCodeGenerator+generateHandlerSelector.swift
+++ b/Sources/SmokeFrameworkCodeGeneration/ServiceModelCodeGenerator+generateHandlerSelector.swift
@@ -43,7 +43,8 @@ extension ServiceModelCodeGenerator {
             import \(baseName)Operations
             import SmokeOperations
             import SmokeOperationsHTTP1
-            
+            import SmokeAsyncHTTP1
+
             """)
         
         fileBuilder.appendLine("""


### PR DESCRIPTION
This changes adds a missing import for SmokeAsyncHTTP in the handler selector file to fix failing builds.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
