### PR TITLE
Support async initialization

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -15,7 +15,7 @@
         "repositoryURL": "https://github.com/amzn/service-model-swift-code-generate.git",
         "state": {
           "branch": "main",
-          "revision": "58ea14b91fabf1052dd01f3c617415de7636d1ea",
+          "revision": "6e4710b64c54cf91530b0438b6635f34877e56a5",
           "version": null
         }
       },
@@ -24,7 +24,7 @@
         "repositoryURL": "https://github.com/amzn/smoke-aws-generate.git",
         "state": {
           "branch": "main",
-          "revision": "80c231a52d89c2fc316c8969b1840814219c1a67",
+          "revision": "b7750e69e09f0b357f102a6ad7eb8b35edf7c11a",
           "version": null
         }
       },
@@ -42,8 +42,8 @@
         "repositoryURL": "https://github.com/apple/swift-argument-parser",
         "state": {
           "branch": null,
-          "revision": "83b23d940471b313427da226196661856f6ba3e0",
-          "version": "0.4.4"
+          "revision": "6b2aa2748a7881eebb9f84fb10c01293e15b52ca",
+          "version": "0.5.0"
         }
       },
       {

--- a/Sources/SmokeFrameworkApplicationGenerate/SmokeFrameworkCodeGen.swift
+++ b/Sources/SmokeFrameworkApplicationGenerate/SmokeFrameworkCodeGen.swift
@@ -28,6 +28,7 @@ struct SmokeFrameworkCodeGen: Codable {
     let modelOverride: ModelOverride?
     let httpClientConfiguration: HttpClientConfiguration?
     let asyncAwait: AsyncAwaitCodeGenParameters?
+    let eventLoopFutureOperationHandlers: CodeGenFeatureStatus?
     let initializationType: InitializationType?
     let testDiscovery: CodeGenFeatureStatus?
     let mainAnnotation: CodeGenFeatureStatus?

--- a/Sources/SmokeFrameworkApplicationGenerate/SmokeFrameworkCodeGen.swift
+++ b/Sources/SmokeFrameworkApplicationGenerate/SmokeFrameworkCodeGen.swift
@@ -9,18 +9,13 @@ import ServiceModelCodeGeneration
 
 struct AsyncAwaitCodeGenParameters: Codable {
     let clientAPIs: CodeGenFeatureStatus
-    // Allow server async/await support when XCTest supports it
-    // https://github.com/apple/swift-corelibs-xctest/pull/331
-    //let asyncOperationStubs: AsyncAwaitSupport
+    let asyncOperationStubs: CodeGenFeatureStatus
+    let asyncInitialization: CodeGenFeatureStatus
 
     static var `default`: AsyncAwaitCodeGenParameters {
-        return AsyncAwaitCodeGenParameters(clientAPIs: .enabled)
-    }
-}
-
-extension AsyncAwaitCodeGenParameters {
-    var asyncOperationStubs: CodeGenFeatureStatus {
-        return .disabled
+        return AsyncAwaitCodeGenParameters(clientAPIs: .enabled,
+                                           asyncOperationStubs: .enabled,
+                                           asyncInitialization: .disabled)
     }
 }
 

--- a/Sources/SmokeFrameworkApplicationGenerate/main.swift
+++ b/Sources/SmokeFrameworkApplicationGenerate/main.swift
@@ -127,6 +127,7 @@ private func startCodeGeneration(
             initializationType: initializationType,
             testDiscovery: testDiscovery,
             mainAnnotation: mainAnnotation,
+            asyncInitialization: asyncAwait.asyncInitialization,
             modelOverride: modelOverride)
     } else if swaggerFileVersion == 2 {
         return try SmokeFrameworkCodeGeneration.generateFromModel(
@@ -140,6 +141,7 @@ private func startCodeGeneration(
             initializationType: initializationType,
             testDiscovery: testDiscovery,
             mainAnnotation: mainAnnotation,
+            asyncInitialization: asyncAwait.asyncInitialization,
             modelOverride: modelOverride)
     } else {
         fatalError("Invalid swagger version.")

--- a/Sources/SmokeFrameworkApplicationGenerate/main.swift
+++ b/Sources/SmokeFrameworkApplicationGenerate/main.swift
@@ -41,6 +41,7 @@ struct Parameters {
     var generateCodeGenConfig: Bool?
     var httpClientConfiguration: ConfigurationProvider<HttpClientConfiguration>?
     var asyncAwait: AsyncAwaitCodeGenParameters?
+    var eventLoopFutureOperationHandlers: CodeGenFeatureStatus?
     var initializationType: InitializationType?
     var testDiscovery: CodeGenFeatureStatus?
     var mainAnnotation: CodeGenFeatureStatus?
@@ -90,12 +91,13 @@ private func startCodeGeneration(
         applicationDescription: String, applicationSuffix: String,
         modelFilePath: String, generationType: GenerationType,
         asyncAwait: AsyncAwaitCodeGenParameters,
+        eventLoopFutureOperationHandlers: CodeGenFeatureStatus,
         initializationType: InitializationType,
         testDiscovery: CodeGenFeatureStatus,
         mainAnnotation: CodeGenFeatureStatus,
         operationStubGenerationRule: OperationStubGenerationRule,
         modelOverride: ModelOverride?,
-    swaggerFileVersion: Int) throws -> ServiceModel {
+        swaggerFileVersion: Int) throws -> ServiceModel {
     let validationErrorDeclaration = ErrorDeclaration.external(
         libraryImport: "SmokeOperations",
         errorType: "SmokeOperationsError")
@@ -124,6 +126,7 @@ private func startCodeGeneration(
             applicationDescription: fullApplicationDescription,
             operationStubGenerationRule: operationStubGenerationRule,
             asyncOperationStubs: asyncAwait.asyncOperationStubs,
+            eventLoopFutureOperationHandlers: eventLoopFutureOperationHandlers,
             initializationType: initializationType,
             testDiscovery: testDiscovery,
             mainAnnotation: mainAnnotation,
@@ -138,6 +141,7 @@ private func startCodeGeneration(
             applicationDescription: fullApplicationDescription,
             operationStubGenerationRule: operationStubGenerationRule,
             asyncOperationStubs: asyncAwait.asyncOperationStubs,
+            eventLoopFutureOperationHandlers: eventLoopFutureOperationHandlers,
             initializationType: initializationType,
             testDiscovery: testDiscovery,
             mainAnnotation: mainAnnotation,
@@ -193,6 +197,7 @@ func handleApplication(parameters: Parameters) throws {
         applicationSuffix: applicationSuffix, modelFilePath: parameters.modelFilePath,
         generationType: parameters.generationType,
         asyncAwait: parameters.asyncAwait ?? .default,
+        eventLoopFutureOperationHandlers: parameters.eventLoopFutureOperationHandlers ?? .disabled,
         initializationType: parameters.initializationType ?? .original,
         testDiscovery: parameters.testDiscovery ?? .disabled,
         mainAnnotation: parameters.mainAnnotation ?? .disabled,
@@ -222,6 +227,7 @@ func handleApplication(parameters: Parameters) throws {
                                                           modelOverride: modelOverride,
                                                           httpClientConfiguration: httpClientConfigurationOptional,
                                                           asyncAwait: parameters.asyncAwait,
+                                                          eventLoopFutureOperationHandlers: parameters.eventLoopFutureOperationHandlers,
                                                           initializationType: parameters.initializationType,
                                                           testDiscovery: parameters.testDiscovery,
                                                           mainAnnotation: parameters.mainAnnotation,
@@ -395,6 +401,7 @@ struct SmokeFrameworkApplicationGenerateCommand: ParsableCommand {
             generateCodeGenConfig: generateCodeGenConfig ?? false,
             httpClientConfiguration: httpClientConfiguration,
             asyncAwait: config?.asyncAwait,
+            eventLoopFutureOperationHandlers: config?.eventLoopFutureOperationHandlers,
             initializationType: config?.initializationType,
             testDiscovery: config?.testDiscovery,
             mainAnnotation: config?.mainAnnotation,

--- a/Sources/SmokeFrameworkCodeGeneration/ServiceModelCodeGenerator+generateHandlerSelector.swift
+++ b/Sources/SmokeFrameworkCodeGeneration/ServiceModelCodeGenerator+generateHandlerSelector.swift
@@ -24,7 +24,8 @@ extension ServiceModelCodeGenerator {
      Generate the hander selector for the operation handlers for the generated application.
      */
     func generateServerHanderSelector(operationStubGenerationRule: OperationStubGenerationRule,
-                                      initializationType: InitializationType) {
+                                      initializationType: InitializationType,
+                                      eventLoopFutureOperationHandlers: CodeGenFeatureStatus) {
         
         let fileBuilder = FileBuilder()
         let baseName = applicationDescription.baseName
@@ -43,9 +44,17 @@ extension ServiceModelCodeGenerator {
             import \(baseName)Operations
             import SmokeOperations
             import SmokeOperationsHTTP1
-            import SmokeAsyncHTTP1
 
             """)
+        
+        if eventLoopFutureOperationHandlers == .enabled {
+            fileBuilder.appendLine("""
+                import SmokeAsyncHTTP1
+                """)
+        } else {
+            fileBuilder.appendLine("""
+                """)
+        }
         
         fileBuilder.appendLine("""
             extension \(baseName)ModelOperations: OperationIdentity {}

--- a/Sources/SmokeFrameworkCodeGeneration/SmokeFrameworkCodeGeneration.swift
+++ b/Sources/SmokeFrameworkCodeGeneration/SmokeFrameworkCodeGeneration.swift
@@ -128,6 +128,7 @@ public struct SmokeFrameworkCodeGeneration {
         applicationDescription: ApplicationDescription,
         operationStubGenerationRule: OperationStubGenerationRule,
         asyncOperationStubs: CodeGenFeatureStatus,
+        eventLoopFutureOperationHandlers: CodeGenFeatureStatus,
         initializationType: InitializationType,
         testDiscovery: CodeGenFeatureStatus,
         mainAnnotation: CodeGenFeatureStatus,
@@ -142,7 +143,8 @@ public struct SmokeFrameworkCodeGeneration {
                                                     mainAnnotation: mainAnnotation,
                                                     asyncInitialization: asyncInitialization,
                                                     operationStubGenerationRule: operationStubGenerationRule,
-                                                    asyncOperationStubs: asyncOperationStubs)
+                                                    asyncOperationStubs: asyncOperationStubs,
+                                                    eventLoopFutureOperationHandlers: eventLoopFutureOperationHandlers)
             }
         
             return try ServiceModelGenerate.generateFromModel(
@@ -164,7 +166,8 @@ extension ServiceModelCodeGenerator {
                                                     mainAnnotation: CodeGenFeatureStatus,
                                                     asyncInitialization: CodeGenFeatureStatus,
                                                     operationStubGenerationRule: OperationStubGenerationRule,
-                                                    asyncOperationStubs: CodeGenFeatureStatus) throws {
+                                                    asyncOperationStubs: CodeGenFeatureStatus,
+                                                    eventLoopFutureOperationHandlers: CodeGenFeatureStatus) throws {
         let clientProtocolDelegate = ClientProtocolDelegate(
             baseName: applicationDescription.baseName,
             asyncAwaitAPIs: asyncAwaitClientAPIs)
@@ -185,7 +188,8 @@ extension ServiceModelCodeGenerator {
         generateServerOperationHandlerStubs(generationType: generationType, operationStubGenerationRule: operationStubGenerationRule,
                                             asyncOperationStubs: asyncOperationStubs)
         generateServerHanderSelector(operationStubGenerationRule: operationStubGenerationRule,
-                                     initializationType: initializationType)
+                                     initializationType: initializationType,
+                                     eventLoopFutureOperationHandlers: eventLoopFutureOperationHandlers)
         generateServerApplicationFiles(generationType: generationType, asyncOperationStubs: asyncOperationStubs,
                                        mainAnnotation: mainAnnotation)
         generateOperationsContext(generationType: generationType)

--- a/Sources/SmokeFrameworkCodeGeneration/SmokeFrameworkCodeGeneration.swift
+++ b/Sources/SmokeFrameworkCodeGeneration/SmokeFrameworkCodeGeneration.swift
@@ -131,6 +131,7 @@ public struct SmokeFrameworkCodeGeneration {
         initializationType: InitializationType,
         testDiscovery: CodeGenFeatureStatus,
         mainAnnotation: CodeGenFeatureStatus,
+        asyncInitialization: CodeGenFeatureStatus,
         modelOverride: ModelOverride?) throws -> ModelType {
             func generatorFunction(codeGenerator: ServiceModelCodeGenerator,
                                    serviceModel: ModelType) throws {
@@ -139,6 +140,7 @@ public struct SmokeFrameworkCodeGeneration {
                                                     initializationType: initializationType,
                                                     testDiscovery: testDiscovery,
                                                     mainAnnotation: mainAnnotation,
+                                                    asyncInitialization: asyncInitialization,
                                                     operationStubGenerationRule: operationStubGenerationRule,
                                                     asyncOperationStubs: asyncOperationStubs)
             }
@@ -160,6 +162,7 @@ extension ServiceModelCodeGenerator {
                                                     initializationType: InitializationType,
                                                     testDiscovery: CodeGenFeatureStatus,
                                                     mainAnnotation: CodeGenFeatureStatus,
+                                                    asyncInitialization: CodeGenFeatureStatus,
                                                     operationStubGenerationRule: OperationStubGenerationRule,
                                                     asyncOperationStubs: CodeGenFeatureStatus) throws {
         let clientProtocolDelegate = ClientProtocolDelegate(
@@ -187,7 +190,7 @@ extension ServiceModelCodeGenerator {
                                        mainAnnotation: mainAnnotation)
         generateOperationsContext(generationType: generationType)
         generateOperationsContextGenerator(generationType: generationType, initializationType: initializationType,
-                                           mainAnnotation: mainAnnotation)
+                                           mainAnnotation: mainAnnotation, asyncInitialization: asyncInitialization)
         generateOperationTests(generationType: generationType, operationStubGenerationRule: operationStubGenerationRule,
                                asyncOperationStubs: asyncOperationStubs, testDiscovery: testDiscovery)
         generateTestConfiguration(generationType: generationType)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

1. Add option for async initialization.
2. Add option for enabling EventLoopFuture-returning operation handlers rather than always enabled by default (Package.swift also needs to be changed when this is enabled; this reverts the default behaviour to what it was prior to #27)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
