### PR TITLE
Generate async initialisation and shutdown methods.

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,11 @@ Create a `smoke-framework-codegen.json` file in the directory you have created w
   "initializationType": "STREAMLINED",
   "testDiscovery": "ENABLED",
   "mainAnnotation": "ENABLED",
+  "asyncAwait": {
+    "clientAPIs": "ENABLED",
+    "asyncOperationStubs": "ENABLED",
+    "asyncInitialization": "ENABLED"
+  },
   "operationStubGenerationRule" : {
     "mode" : "allFunctionsWithinContext"
   }
@@ -56,7 +61,12 @@ This JSON file can contain the following fields-
 * **generationType**: `server` to generate a new service; `serverUpdate` to preserve changes to existing operation handlers. Required.
 * **applicationDescription**: A description of the application. Optional.
 * **modelOverride**: A set of overrides to apply to the model. Optional.
-* **httpClientConfiguration**: Configuration for the generated http service clients. The schema for this parameOptional.
+* **initializationType**: `STREAMLINED` is recommended and uses a code generated initializer protocol to reduce the manual setup required. `ORIGINAL` requires additional manual initialization. Optional; defaulting to `ORIGINAL` for legacy applications.
+* **testDiscovery**: `ENABLED` is recommended and will not generate `LinuxMain.swift` and associated TestCase lists. `DISABLED` will code generate these. Optional; defaulting to `DISABLED` for legacy applications.
+* **mainAnnotation**: `ENABLED` is recommended and will not generate `main.swift` and will instead specify the @main annotation on the application initializer. `DISABLED` will code generate `main.swift`. Optional; defaulting to `DISABLED` for legacy applications.
+* **asyncAwait**: Specifies if 1) async client APIs will be generated, 2) operation handler stubs will be code generated as async methods and 3) if the initialization and shutdown methods can be async methods (and will code generated as such if they don't exist). Optional; by default `clientAPIs` and `asyncOperationStubs` will be enabled but `asyncInitialization` will be disabled for legacy applications. 
+* **eventLoopFutureOperationHandlers**: `ENABLED` will support the use of `EventLoopFuture`-returning operation handlers. Integration for these types of handlers are contained in the `SmokeAsyncHTTP1` product of the `smoke-framework` package. A dependency on this product will need to be added to the `\(applicationBaseName)OperationsHTTP1` product of the code generated application if this option is enabled. Optional, disabled by default.
+* **httpClientConfiguration**: Configuration for the generated http service clients. Optional.
 * **operationStubGenerationRule**: How operation stubs are generated and expected by the application. It is recommended that new applications use `allFunctionsWithinContext` which will generate operation stubs within extensions of the Context type[1].
 
 The schemas for the `modelOverride` and `httpClientConfiguration` fields can be found here - https://github.com/amzn/service-model-swift-code-generate/blob/main/Sources/ServiceModelEntities/ModelOverride.swift.

--- a/Sources/SmokeFrameworkApplicationGenerate/SmokeFrameworkCodeGen.swift
+++ b/Sources/SmokeFrameworkApplicationGenerate/SmokeFrameworkCodeGen.swift
@@ -10,12 +10,12 @@ import ServiceModelCodeGeneration
 struct AsyncAwaitCodeGenParameters: Codable {
     let clientAPIs: CodeGenFeatureStatus
     let asyncOperationStubs: CodeGenFeatureStatus
-    let asyncInitialization: CodeGenFeatureStatus
+    let asyncInitialization: CodeGenFeatureStatus?
 
     static var `default`: AsyncAwaitCodeGenParameters {
         return AsyncAwaitCodeGenParameters(clientAPIs: .enabled,
                                            asyncOperationStubs: .enabled,
-                                           asyncInitialization: .disabled)
+                                           asyncInitialization: nil)
     }
 }
 

--- a/Sources/SmokeFrameworkApplicationGenerate/main.swift
+++ b/Sources/SmokeFrameworkApplicationGenerate/main.swift
@@ -130,7 +130,7 @@ private func startCodeGeneration(
             initializationType: initializationType,
             testDiscovery: testDiscovery,
             mainAnnotation: mainAnnotation,
-            asyncInitialization: asyncAwait.asyncInitialization,
+            asyncInitialization: asyncAwait.asyncInitialization ?? .disabled,
             modelOverride: modelOverride)
     } else if swaggerFileVersion == 2 {
         return try SmokeFrameworkCodeGeneration.generateFromModel(
@@ -145,7 +145,7 @@ private func startCodeGeneration(
             initializationType: initializationType,
             testDiscovery: testDiscovery,
             mainAnnotation: mainAnnotation,
-            asyncInitialization: asyncAwait.asyncInitialization,
+            asyncInitialization: asyncAwait.asyncInitialization ?? .disabled,
             modelOverride: modelOverride)
     } else {
         fatalError("Invalid swagger version.")

--- a/Sources/SmokeFrameworkCodeGeneration/ServiceModelCodeGenerator+generateHandlerSelector.swift
+++ b/Sources/SmokeFrameworkCodeGeneration/ServiceModelCodeGenerator+generateHandlerSelector.swift
@@ -44,12 +44,12 @@ extension ServiceModelCodeGenerator {
             import \(baseName)Operations
             import SmokeOperations
             import SmokeOperationsHTTP1
-
             """)
         
         if eventLoopFutureOperationHandlers == .enabled {
             fileBuilder.appendLine("""
                 import SmokeAsyncHTTP1
+                
                 """)
         } else {
             fileBuilder.appendLine("""

--- a/Sources/SmokeFrameworkCodeGeneration/ServiceModelCodeGenerator+generatePerInvocationContextInitializer.swift
+++ b/Sources/SmokeFrameworkCodeGeneration/ServiceModelCodeGenerator+generatePerInvocationContextInitializer.swift
@@ -146,6 +146,14 @@ extension ServiceModelCodeGenerator {
             }
         }
         
+        let asyncPrefix: String
+        switch asyncInitialization {
+        case .disabled:
+            asyncPrefix = ""
+        case .enabled:
+            asyncPrefix = "async "
+        }
+        
         fileBuilder.appendLine("""
             //
             // \(baseName)PerInvocationContextInitializer.swift
@@ -176,7 +184,7 @@ extension ServiceModelCodeGenerator {
                 /**
                  On application startup.
                  */
-                init(eventLoopGroup: EventLoopGroup) throws {
+                init(eventLoopGroup: EventLoopGroup) \(asyncPrefix)throws {
                     CloudwatchStandardErrorLogger.enableLogging()
             
                     // TODO: Add additional application initialization
@@ -193,7 +201,7 @@ extension ServiceModelCodeGenerator {
                 /**
                  On application shutdown.
                 */
-                func onShutdown() throws {
+                func onShutdown() \(asyncPrefix)throws {
                     
                 }
             }

--- a/Sources/SmokeFrameworkCodeGeneration/ServiceModelCodeGenerator+generateServerApplicationFiles.swift
+++ b/Sources/SmokeFrameworkCodeGeneration/ServiceModelCodeGenerator+generateServerApplicationFiles.swift
@@ -81,17 +81,6 @@ extension ServiceModelCodeGenerator {
             }
         }
         
-        let macOSVersion: String
-        let iOSVersion: String
-        switch asyncOperationStubs {
-        case .disabled:
-            macOSVersion = ".v10_15"
-            iOSVersion = ".v10"
-        case .enabled:
-            macOSVersion = ".v12"
-            iOSVersion = ".v15"
-        }
-        
         fileBuilder.appendLine("""
             // swift-tools-version:5.5
             // The swift-tools-version declares the minimum version of Swift required to build this package.
@@ -101,7 +90,7 @@ extension ServiceModelCodeGenerator {
             let package = Package(
                 name: "\(baseName)",
                 platforms: [
-                  .macOS(\(macOSVersion)), .iOS(\(iOSVersion))
+                  .macOS(.v10_15), .iOS(.v10)
                 ],
                 products: [
                     // Products define the executables and libraries produced by a package, and make them visible to other packages.


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
1. Generate async initialisation and shutdown methods when async initialisation is enabled.
2. Make `asyncInitialization` optional in the `smoke-framework-codegen.json` config file. This doesn't change any behaviour but addresses a breaking change introduced in #28.
3. Fix spacing around the `SmokeAsyncHTTP1` import.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
