### PR TITLE
Support generator as SPM plugin and add option for OpenAPI 3.0 model.

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -12,10 +12,10 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-20.04]
-        swift: ["5.5", "5.3.3"]
+        swift: ["5.6", "5.5.3"]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: marcprux/setup-swift@a990bc57c514a77d232b645843ade099af21aa5e
+      - uses: fwal/setup-swift@v1.14.0
         with:
           swift-version: ${{ matrix.swift }}
       - uses: actions/checkout@v2
@@ -29,7 +29,7 @@ jobs:
         swift: ["5.4.3"]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: marcprux/setup-swift@a990bc57c514a77d232b645843ade099af21aa5e
+      - uses: fwal/setup-swift@v1.14.0
         with:
           swift-version: ${{ matrix.swift }}
       - uses: actions/checkout@v2

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,59 +1,61 @@
 {
-  "pins" : [
-    {
-      "identity" : "openapikit",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/mattpolzin/OpenAPIKit.git",
-      "state" : {
-        "revision" : "0c668112f9803c1858ed070f9e8ce84922a0b41f",
-        "version" : "3.0.0-alpha.4"
+  "object": {
+    "pins": [
+      {
+        "package": "OpenAPIKit",
+        "repositoryURL": "https://github.com/mndzup/OpenAPIKit.git",
+        "state": {
+          "branch": "main",
+          "revision": "4f406328cb4543fe9d27325949f01914ca2c9863",
+          "version": null
+        }
+      },
+      {
+        "package": "ServiceModelSwiftCodeGenerate",
+        "repositoryURL": "https://github.com/amzn/service-model-swift-code-generate.git",
+        "state": {
+          "branch": "main",
+          "revision": "6e4710b64c54cf91530b0438b6635f34877e56a5",
+          "version": null
+        }
+      },
+      {
+        "package": "SmokeAWSGenerate",
+        "repositoryURL": "https://github.com/amzn/smoke-aws-generate.git",
+        "state": {
+          "branch": "main",
+          "revision": "b7750e69e09f0b357f102a6ad7eb8b35edf7c11a",
+          "version": null
+        }
+      },
+      {
+        "package": "SwaggerParser",
+        "repositoryURL": "https://github.com/tachyonics/SwaggerParser.git",
+        "state": {
+          "branch": null,
+          "revision": "c0eb70485c59a9d7dd6765dcd303b49fdb3040ee",
+          "version": "0.6.4"
+        }
+      },
+      {
+        "package": "swift-argument-parser",
+        "repositoryURL": "https://github.com/apple/swift-argument-parser",
+        "state": {
+          "branch": null,
+          "revision": "6b2aa2748a7881eebb9f84fb10c01293e15b52ca",
+          "version": "0.5.0"
+        }
+      },
+      {
+        "package": "Yams",
+        "repositoryURL": "https://github.com/jpsim/Yams.git",
+        "state": {
+          "branch": null,
+          "revision": "9ff1cc9327586db4e0c8f46f064b6a82ec1566fa",
+          "version": "4.0.6"
+        }
       }
-    },
-    {
-      "identity" : "service-model-swift-code-generate",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/amzn/service-model-swift-code-generate.git",
-      "state" : {
-        "revision" : "286181816fccc2b6ec92049ba68426d08cbe0059",
-        "version" : "3.0.0-beta.1"
-      }
-    },
-    {
-      "identity" : "smoke-aws-generate",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/amzn/smoke-aws-generate.git",
-      "state" : {
-        "revision" : "2d2902403408d4c7a9f6c69c90975cc048759f95",
-        "version" : "3.0.0-beta.1"
-      }
-    },
-    {
-      "identity" : "swaggerparser",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/tachyonics/SwaggerParser.git",
-      "state" : {
-        "revision" : "c0eb70485c59a9d7dd6765dcd303b49fdb3040ee",
-        "version" : "0.6.4"
-      }
-    },
-    {
-      "identity" : "swift-argument-parser",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-argument-parser",
-      "state" : {
-        "revision" : "6b2aa2748a7881eebb9f84fb10c01293e15b52ca",
-        "version" : "0.5.0"
-      }
-    },
-    {
-      "identity" : "yams",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/jpsim/Yams.git",
-      "state" : {
-        "revision" : "9ff1cc9327586db4e0c8f46f064b6a82ec1566fa",
-        "version" : "4.0.6"
-      }
-    }
-  ],
-  "version" : 2
+    ]
+  },
+  "version": 1
 }

--- a/Package.resolved
+++ b/Package.resolved
@@ -3,29 +3,29 @@
     "pins": [
       {
         "package": "OpenAPIKit",
-        "repositoryURL": "https://github.com/mndzup/OpenAPIKit.git",
+        "repositoryURL": "https://github.com/mattpolzin/OpenAPIKit.git",
         "state": {
-          "branch": "main",
-          "revision": "4f406328cb4543fe9d27325949f01914ca2c9863",
-          "version": null
+          "branch": null,
+          "revision": "0c668112f9803c1858ed070f9e8ce84922a0b41f",
+          "version": "3.0.0-alpha.4"
         }
       },
       {
         "package": "ServiceModelSwiftCodeGenerate",
         "repositoryURL": "https://github.com/amzn/service-model-swift-code-generate.git",
         "state": {
-          "branch": "main",
-          "revision": "6e4710b64c54cf91530b0438b6635f34877e56a5",
-          "version": null
+          "branch": null,
+          "revision": "286181816fccc2b6ec92049ba68426d08cbe0059",
+          "version": "3.0.0-beta.1"
         }
       },
       {
         "package": "SmokeAWSGenerate",
         "repositoryURL": "https://github.com/amzn/smoke-aws-generate.git",
         "state": {
-          "branch": "main",
-          "revision": "b7750e69e09f0b357f102a6ad7eb8b35edf7c11a",
-          "version": null
+          "branch": null,
+          "revision": "2d2902403408d4c7a9f6c69c90975cc048759f95",
+          "version": "3.0.0-beta.1"
         }
       },
       {

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,61 +1,59 @@
 {
-  "object": {
-    "pins": [
-      {
-        "package": "OpenAPIKit",
-        "repositoryURL": "https://github.com/mndzup/OpenAPIKit.git",
-        "state": {
-          "branch": "main",
-          "revision": "4f406328cb4543fe9d27325949f01914ca2c9863",
-          "version": null
-        }
-      },
-      {
-        "package": "ServiceModelSwiftCodeGenerate",
-        "repositoryURL": "https://github.com/amzn/service-model-swift-code-generate.git",
-        "state": {
-          "branch": "main",
-          "revision": "6e4710b64c54cf91530b0438b6635f34877e56a5",
-          "version": null
-        }
-      },
-      {
-        "package": "SmokeAWSGenerate",
-        "repositoryURL": "https://github.com/amzn/smoke-aws-generate.git",
-        "state": {
-          "branch": "main",
-          "revision": "b7750e69e09f0b357f102a6ad7eb8b35edf7c11a",
-          "version": null
-        }
-      },
-      {
-        "package": "SwaggerParser",
-        "repositoryURL": "https://github.com/tachyonics/SwaggerParser.git",
-        "state": {
-          "branch": null,
-          "revision": "c0eb70485c59a9d7dd6765dcd303b49fdb3040ee",
-          "version": "0.6.4"
-        }
-      },
-      {
-        "package": "swift-argument-parser",
-        "repositoryURL": "https://github.com/apple/swift-argument-parser",
-        "state": {
-          "branch": null,
-          "revision": "6b2aa2748a7881eebb9f84fb10c01293e15b52ca",
-          "version": "0.5.0"
-        }
-      },
-      {
-        "package": "Yams",
-        "repositoryURL": "https://github.com/jpsim/Yams.git",
-        "state": {
-          "branch": null,
-          "revision": "9ff1cc9327586db4e0c8f46f064b6a82ec1566fa",
-          "version": "4.0.6"
-        }
+  "pins" : [
+    {
+      "identity" : "openapikit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/mattpolzin/OpenAPIKit.git",
+      "state" : {
+        "revision" : "0c668112f9803c1858ed070f9e8ce84922a0b41f",
+        "version" : "3.0.0-alpha.4"
       }
-    ]
-  },
-  "version": 1
+    },
+    {
+      "identity" : "service-model-swift-code-generate",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/amzn/service-model-swift-code-generate.git",
+      "state" : {
+        "revision" : "286181816fccc2b6ec92049ba68426d08cbe0059",
+        "version" : "3.0.0-beta.1"
+      }
+    },
+    {
+      "identity" : "smoke-aws-generate",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/amzn/smoke-aws-generate.git",
+      "state" : {
+        "revision" : "2d2902403408d4c7a9f6c69c90975cc048759f95",
+        "version" : "3.0.0-beta.1"
+      }
+    },
+    {
+      "identity" : "swaggerparser",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/tachyonics/SwaggerParser.git",
+      "state" : {
+        "revision" : "c0eb70485c59a9d7dd6765dcd303b49fdb3040ee",
+        "version" : "0.6.4"
+      }
+    },
+    {
+      "identity" : "swift-argument-parser",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-argument-parser",
+      "state" : {
+        "revision" : "6b2aa2748a7881eebb9f84fb10c01293e15b52ca",
+        "version" : "0.5.0"
+      }
+    },
+    {
+      "identity" : "yams",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/jpsim/Yams.git",
+      "state" : {
+        "revision" : "9ff1cc9327586db4e0c8f46f064b6a82ec1566fa",
+        "version" : "4.0.6"
+      }
+    }
+  ],
+  "version" : 2
 }

--- a/Package@swift-5.4.swift
+++ b/Package@swift-5.4.swift
@@ -29,22 +29,24 @@ let package = Package(
             targets: ["SmokeFrameworkCodeGeneration"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/amzn/smoke-aws-generate.git", from: "3.0.0-beta.1"),
-        .package(url: "https://github.com/amzn/service-model-swift-code-generate.git", from: "3.0.0-beta.1"),
+        .package(name: "SmokeAWSGenerate",
+                 url: "https://github.com/amzn/smoke-aws-generate.git", from: "3.0.0-beta.1"),
+        .package(name: "ServiceModelSwiftCodeGenerate",
+                 url: "https://github.com/amzn/service-model-swift-code-generate.git", from: "3.0.0-beta.1"),
         .package(url: "https://github.com/apple/swift-argument-parser", from: "0.3.0"),
     ],
     targets: [
         .executableTarget(
             name: "SmokeFrameworkApplicationGenerate", dependencies: [
                 .target(name: "SmokeFrameworkCodeGeneration"),
-                .product(name: "OpenAPIServiceModel", package: "service-model-swift-code-generate"),
+                .product(name: "OpenAPIServiceModel", package: "ServiceModelSwiftCodeGenerate"),
                 .product(name: "ArgumentParser", package: "swift-argument-parser"),
             ]
         ),
         .target(
             name: "SmokeFrameworkCodeGeneration", dependencies: [
-                .product(name: "ServiceModelGenerate", package: "service-model-swift-code-generate"),
-                .product(name: "SmokeAWSModelGenerate", package: "smoke-aws-generate"),
+                .product(name: "ServiceModelGenerate", package: "ServiceModelSwiftCodeGenerate"),
+                .product(name: "SmokeAWSModelGenerate", package: "SmokeAWSGenerate"),
             ]
         ),
         .testTarget(

--- a/Package@swift-5.4.swift
+++ b/Package@swift-5.4.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.6
+// swift-tools-version:5.4
 //
 // Copyright 2019-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
@@ -27,15 +27,6 @@ let package = Package(
         .library(
             name: "SmokeFrameworkCodeGeneration",
             targets: ["SmokeFrameworkCodeGeneration"]),
-        .plugin(
-            name: "SmokeFrameworkGenerateModel",
-            targets: ["SmokeFrameworkGenerateModel"]),
-        .plugin(
-            name: "SmokeFrameworkGenerateClient",
-            targets: ["SmokeFrameworkGenerateClient"]),
-        .plugin(
-            name: "SmokeFrameworkGenerateHttp1",
-            targets: ["SmokeFrameworkGenerateHttp1"]),
     ],
     dependencies: [
         .package(url: "https://github.com/amzn/smoke-aws-generate.git", from: "3.0.0-beta.1"),
@@ -43,21 +34,6 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-argument-parser", from: "0.3.0"),
     ],
     targets: [
-        .plugin(
-            name: "SmokeFrameworkGenerateModel",
-            capability: .buildTool(),
-            dependencies: ["SmokeFrameworkApplicationGenerate"]
-        ),
-        .plugin(
-            name: "SmokeFrameworkGenerateClient",
-            capability: .buildTool(),
-            dependencies: ["SmokeFrameworkApplicationGenerate"]
-        ),
-        .plugin(
-            name: "SmokeFrameworkGenerateHttp1",
-            capability: .buildTool(),
-            dependencies: ["SmokeFrameworkApplicationGenerate"]
-        ),
         .executableTarget(
             name: "SmokeFrameworkApplicationGenerate", dependencies: [
                 .target(name: "SmokeFrameworkCodeGeneration"),

--- a/Package@swift-5.5.swift
+++ b/Package@swift-5.5.swift
@@ -29,22 +29,24 @@ let package = Package(
             targets: ["SmokeFrameworkCodeGeneration"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/amzn/smoke-aws-generate.git", from: "3.0.0-beta.1"),
-        .package(url: "https://github.com/amzn/service-model-swift-code-generate.git", from: "3.0.0-beta.1"),
+        .package(name: "SmokeAWSGenerate",
+                 url: "https://github.com/amzn/smoke-aws-generate.git", from: "3.0.0-beta.1"),
+        .package(name: "ServiceModelSwiftCodeGenerate",
+                 url: "https://github.com/amzn/service-model-swift-code-generate.git", from: "3.0.0-beta.1"),
         .package(url: "https://github.com/apple/swift-argument-parser", from: "0.3.0"),
     ],
     targets: [
         .executableTarget(
             name: "SmokeFrameworkApplicationGenerate", dependencies: [
                 .target(name: "SmokeFrameworkCodeGeneration"),
-                .product(name: "OpenAPIServiceModel", package: "service-model-swift-code-generate"),
+                .product(name: "OpenAPIServiceModel", package: "ServiceModelSwiftCodeGenerate"),
                 .product(name: "ArgumentParser", package: "swift-argument-parser"),
             ]
         ),
         .target(
             name: "SmokeFrameworkCodeGeneration", dependencies: [
-                .product(name: "ServiceModelGenerate", package: "service-model-swift-code-generate"),
-                .product(name: "SmokeAWSModelGenerate", package: "smoke-aws-generate"),
+                .product(name: "ServiceModelGenerate", package: "ServiceModelSwiftCodeGenerate"),
+                .product(name: "SmokeAWSModelGenerate", package: "SmokeAWSGenerate"),
             ]
         ),
         .testTarget(

--- a/Package@swift-5.5.swift
+++ b/Package@swift-5.5.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.6
+// swift-tools-version:5.4
 //
 // Copyright 2019-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
@@ -27,15 +27,6 @@ let package = Package(
         .library(
             name: "SmokeFrameworkCodeGeneration",
             targets: ["SmokeFrameworkCodeGeneration"]),
-        .plugin(
-            name: "SmokeFrameworkGenerateModel",
-            targets: ["SmokeFrameworkGenerateModel"]),
-        .plugin(
-            name: "SmokeFrameworkGenerateClient",
-            targets: ["SmokeFrameworkGenerateClient"]),
-        .plugin(
-            name: "SmokeFrameworkGenerateHttp1",
-            targets: ["SmokeFrameworkGenerateHttp1"]),
     ],
     dependencies: [
         .package(url: "https://github.com/amzn/smoke-aws-generate.git", from: "3.0.0-beta.1"),
@@ -43,21 +34,6 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-argument-parser", from: "0.3.0"),
     ],
     targets: [
-        .plugin(
-            name: "SmokeFrameworkGenerateModel",
-            capability: .buildTool(),
-            dependencies: ["SmokeFrameworkApplicationGenerate"]
-        ),
-        .plugin(
-            name: "SmokeFrameworkGenerateClient",
-            capability: .buildTool(),
-            dependencies: ["SmokeFrameworkApplicationGenerate"]
-        ),
-        .plugin(
-            name: "SmokeFrameworkGenerateHttp1",
-            capability: .buildTool(),
-            dependencies: ["SmokeFrameworkApplicationGenerate"]
-        ),
         .executableTarget(
             name: "SmokeFrameworkApplicationGenerate", dependencies: [
                 .target(name: "SmokeFrameworkCodeGeneration"),

--- a/Plugins/SmokeFrameworkGenerateClient/plugin.swift
+++ b/Plugins/SmokeFrameworkGenerateClient/plugin.swift
@@ -1,0 +1,56 @@
+import PackagePlugin
+import Foundation
+
+private let targetSuffix = "Client"
+
+@main
+struct SmokeFrameworkGenerateClientPlugin: BuildToolPlugin {
+    /// This plugin's implementation returns a single build command which
+    /// calls `SmokeFrameworkApplicationGenerate` to generate the service client.
+    func createBuildCommands(context: PluginContext, target: Target) throws -> [Command] {
+        // get the generator tool
+        let smokeFrameworkApplicationGenerateTool = try context.tool(named: "SmokeFrameworkApplicationGenerate")
+        let sourcesDirectory = context.pluginWorkDirectory.appending("Sources")
+        
+        var baseName = target.name
+        if baseName.hasSuffix(targetSuffix) {
+            baseName = String(baseName.dropLast(targetSuffix.count))
+        }
+        let clientDirectory = sourcesDirectory.appending("\(baseName)\(targetSuffix)")
+        
+        let clientFiles = ["APIGateway\(baseName)\(targetSuffix).swift",
+                           "\(baseName)\(targetSuffix)Protocol.swift",
+                           "\(baseName)Operations\(targetSuffix)Output.swift",
+                           "APIGateway\(baseName)\(targetSuffix)Generator.swift",
+                           "\(baseName)InvocationsReporting.swift",
+                           "\(baseName)OperationsReporting.swift",
+                           "Mock\(baseName)\(targetSuffix).swift",
+                           "\(baseName)Operations\(targetSuffix)Input.swift",
+                           "Throwing\(baseName)\(targetSuffix).swift"]
+        let clientOutputPaths = clientFiles.map { clientDirectory.appending($0) }
+        
+        let inputFile = context.package.directory.appending("smoke-framework-codegen.json")
+        
+        // Specifying the input and output paths lets the build system know
+        // when to invoke the command.
+        let inputFiles = [inputFile]
+        let outputFiles = clientOutputPaths
+
+        // Construct the command arguments.
+        let commandArgs = [
+            "--base-file-path", context.package.directory.description,
+            "--base-output-file-path", context.pluginWorkDirectory.description,
+            "--generation-type", "codeGenClient"
+        ]
+
+        // Append a command containing the information we generated.
+        let command: Command = .buildCommand(
+            displayName: "Generating client files",
+            executable: smokeFrameworkApplicationGenerateTool.path,
+            arguments: commandArgs,
+            inputFiles: inputFiles,
+            outputFiles: outputFiles)
+        
+        return [command]
+    }
+}

--- a/Plugins/SmokeFrameworkGenerateHttp1/plugin.swift
+++ b/Plugins/SmokeFrameworkGenerateHttp1/plugin.swift
@@ -1,0 +1,52 @@
+import PackagePlugin
+import Foundation
+
+private let targetSuffix = "OperationsHTTP1"
+
+@main
+struct SmokeFrameworkGenerateHttp1Plugin: BuildToolPlugin {
+    /// This plugin's implementation returns a single build command which
+    /// calls `SmokeFrameworkApplicationGenerate` to generate the http1 protocol integration.
+    func createBuildCommands(context: PluginContext, target: Target) throws -> [Command] {
+        // get the generator tool
+        let smokeFrameworkApplicationGenerateTool = try context.tool(named: "SmokeFrameworkApplicationGenerate")
+        let sourcesDirectory = context.pluginWorkDirectory.appending("Sources")
+        
+        var baseName = target.name
+        if baseName.hasSuffix(targetSuffix) {
+            baseName = String(baseName.dropLast(targetSuffix.count))
+        }
+
+        let http1Directory = sourcesDirectory.appending("\(baseName)\(targetSuffix)")
+        
+        let http1Files = ["\(baseName)OperationsHTTPInput.swift",
+                          "\(baseName)OperationsHanderSelector.swift",
+                          "\(baseName)OperationsHTTPOutput.swift",
+                          "\(baseName)PerInvocationContextInitializerProtocol.swift"]
+        let http1OutputPaths = http1Files.map { http1Directory.appending($0) }
+        
+        let inputFile = context.package.directory.appending("smoke-framework-codegen.json")
+        
+        // Specifying the input and output paths lets the build system know
+        // when to invoke the command.
+        let inputFiles = [inputFile]
+        let outputFiles = http1OutputPaths
+
+        // Construct the command arguments.
+        let commandArgs = [
+            "--base-file-path", context.package.directory.description,
+            "--base-output-file-path", context.pluginWorkDirectory.description,
+            "--generation-type", "codeGenHttp1"
+        ]
+
+        // Append a command containing the information we generated.
+        let command: Command = .buildCommand(
+            displayName: "Generating HTTP1 integration files",
+            executable: smokeFrameworkApplicationGenerateTool.path,
+            arguments: commandArgs,
+            inputFiles: inputFiles,
+            outputFiles: outputFiles)
+        
+        return [command]
+    }
+}

--- a/Plugins/SmokeFrameworkGenerateModel/plugin.swift
+++ b/Plugins/SmokeFrameworkGenerateModel/plugin.swift
@@ -1,0 +1,53 @@
+import PackagePlugin
+import Foundation
+
+private let targetSuffix = "Model"
+
+@main
+struct SmokeFrameworkGenerateModelPlugin: BuildToolPlugin {
+    /// This plugin's implementation returns a single build command which
+    /// calls `SmokeFrameworkApplicationGenerate` to generate the service model.
+    func createBuildCommands(context: PluginContext, target: Target) throws -> [Command] {
+        // get the generator tool
+        let smokeFrameworkApplicationGenerateTool = try context.tool(named: "SmokeFrameworkApplicationGenerate")
+        let sourcesDirectory = context.pluginWorkDirectory.appending("Sources")
+        
+        var baseName = target.name
+        if baseName.hasSuffix(targetSuffix) {
+            baseName = String(baseName.dropLast(targetSuffix.count))
+        }
+        
+        let modelDirectory = sourcesDirectory.appending("\(baseName)\(targetSuffix)")
+        
+        let modelFiles = ["\(baseName)\(targetSuffix)Errors.swift",
+                          "\(baseName)\(targetSuffix)Structures.swift",
+                          "\(baseName)\(targetSuffix)DefaultInstances.swift",
+                          "\(baseName)\(targetSuffix)Operations.swift",
+                          "\(baseName)\(targetSuffix)Types.swift"]
+        let modelOutputPaths = modelFiles.map { modelDirectory.appending($0) }
+        
+        let inputFile = context.package.directory.appending("smoke-framework-codegen.json")
+        
+        // Specifying the input and output paths lets the build system know
+        // when to invoke the command.
+        let inputFiles = [inputFile]
+        let outputFiles = modelOutputPaths
+
+        // Construct the command arguments.
+        let commandArgs = [
+            "--base-file-path", context.package.directory.description,
+            "--base-output-file-path", context.pluginWorkDirectory.description,
+            "--generation-type", "codeGenModel"
+        ]
+
+        // Append a command containing the information we generated.
+        let command: Command = .buildCommand(
+            displayName: "Generating model files",
+            executable: smokeFrameworkApplicationGenerateTool.path,
+            arguments: commandArgs,
+            inputFiles: inputFiles,
+            outputFiles: outputFiles)
+        
+        return [command]
+    }
+}

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 <img src="https://github.com/amzn/smoke-framework-application-generate/actions/workflows/swift.yml/badge.svg?branch=main" alt="Build - main Branch">
 </a>
 <a href="http://swift.org">
-<img src="https://img.shields.io/badge/swift-5.3|5.4|5.5-orange.svg?style=flat" alt="Swift 5.3, 5.4 and 5.5 Tested">
+<img src="https://img.shields.io/badge/swift-5.4|5.5|5.6-orange.svg?style=flat" alt="Swift 5.4, 5.5 and 5.6 Tested">
 </a>
 <a href="https://gitter.im/SmokeServerSide">
 <img src="https://img.shields.io/badge/chat-on%20gitter-ee115e.svg?style=flat" alt="Join the Smoke Server Side community on gitter">

--- a/README.md
+++ b/README.md
@@ -43,6 +43,11 @@ Create a `smoke-framework-codegen.json` file in the directory you have created w
   "initializationType": "STREAMLINED",
   "testDiscovery": "ENABLED",
   "mainAnnotation": "ENABLED",
+  "asyncAwait": {
+    "clientAPIs": "ENABLED",
+    "asyncOperationStubs": "ENABLED",
+    "asyncInitialization": "ENABLED"
+  },
   "operationStubGenerationRule" : {
     "mode" : "allFunctionsWithinContext"
   }
@@ -56,7 +61,12 @@ This JSON file can contain the following fields-
 * **generationType**: `server` to generate a new service; `serverUpdate` to preserve changes to existing operation handlers. Required.
 * **applicationDescription**: A description of the application. Optional.
 * **modelOverride**: A set of overrides to apply to the model. Optional.
-* **httpClientConfiguration**: Configuration for the generated http service clients. The schema for this parameOptional.
+* **initializationType**: `STREAMLINED` is recommended and uses a code generated initializer protocol to reduce the manual setup required. `ORIGINAL` requires additional manual initialization. Optional; defaulting to `ORIGINAL` for legacy applications.
+* **testDiscovery**: `ENABLED` is recommended and will not generate `LinuxMain.swift` and associated TestCase lists. `DISABLED` will code generate these. Optional; defaulting to `DISABLED` for legacy applications.
+* **mainAnnotation**: `ENABLED` is recommended and will not generate `main.swift` and will instead specify the @main annotation on the application initializer. `DISABLED` will code generate `main.swift`. Optional; defaulting to `DISABLED` for legacy applications.
+* **asyncAwait**: Specifies if 1) async client APIs will be generated, 2) operation handler stubs will be code generated as async methods and 3) if the initialization and shutdown methods can be async methods (and will code generated as such if they don't exist). Optional; by default `clientAPIs` and `asyncOperationStubs` will be enabled but `asyncInitialization` will be disabled for legacy applications. 
+* **eventLoopFutureOperationHandlers**: `ENABLED` will support the use of `EventLoopFuture`-returning operation handlers. Integration for these types of handlers are contained in the `SmokeAsyncHTTP1` product of the `smoke-framework` package. A dependency on this product will need to be added to the `\(applicationBaseName)OperationsHTTP1` product of the code generated application if this option is enabled. Optional, disabled by default.
+* **httpClientConfiguration**: Configuration for the generated http service clients. Optional.
 * **operationStubGenerationRule**: How operation stubs are generated and expected by the application. It is recommended that new applications use `allFunctionsWithinContext` which will generate operation stubs within extensions of the Context type[1].
 
 The schemas for the `modelOverride` and `httpClientConfiguration` fields can be found here - https://github.com/amzn/service-model-swift-code-generate/blob/main/Sources/ServiceModelEntities/ModelOverride.swift.

--- a/Sources/SmokeFrameworkApplicationGenerate/SmokeFrameworkCodeGen.swift
+++ b/Sources/SmokeFrameworkApplicationGenerate/SmokeFrameworkCodeGen.swift
@@ -19,8 +19,14 @@ struct AsyncAwaitCodeGenParameters: Codable {
     }
 }
 
+enum ModelFormat: String, Codable {
+    case swagger = "SWAGGER"
+    case openAPI30 = "OPENAPI3_0"
+}
+
 struct SmokeFrameworkCodeGen: Codable {
     let modelFilePath: String
+    let modelFormat: ModelFormat?
     let baseName: String
     let applicationSuffix: String?
     let generationType: GenerationType

--- a/Sources/SmokeFrameworkApplicationGenerate/SmokeFrameworkCodeGen.swift
+++ b/Sources/SmokeFrameworkApplicationGenerate/SmokeFrameworkCodeGen.swift
@@ -10,12 +10,12 @@ import ServiceModelCodeGeneration
 struct AsyncAwaitCodeGenParameters: Codable {
     let clientAPIs: CodeGenFeatureStatus
     let asyncOperationStubs: CodeGenFeatureStatus
-    let asyncInitialization: CodeGenFeatureStatus
+    let asyncInitialization: CodeGenFeatureStatus?
 
     static var `default`: AsyncAwaitCodeGenParameters {
         return AsyncAwaitCodeGenParameters(clientAPIs: .enabled,
                                            asyncOperationStubs: .enabled,
-                                           asyncInitialization: .disabled)
+                                           asyncInitialization: nil)
     }
 }
 

--- a/Sources/SmokeFrameworkApplicationGenerate/main.swift
+++ b/Sources/SmokeFrameworkApplicationGenerate/main.swift
@@ -32,9 +32,11 @@ enum ConfigurationProvider<Type> {
 
 struct Parameters {
     var modelFilePath: String
+    var modelFormat: ModelFormat?
     var baseName: String
     var applicationSuffix: String?
     var baseFilePath: String
+    var baseOutputFilePath: String?
     var generationType: GenerationType
     var applicationDescription: String?
     var modelOverride: ConfigurationProvider<ModelOverride>?
@@ -46,7 +48,6 @@ struct Parameters {
     var testDiscovery: CodeGenFeatureStatus?
     var mainAnnotation: CodeGenFeatureStatus?
     var operationStubGenerationRule: OperationStubGenerationRule
-    var swaggerFileVersion: Int
 }
 
 private func getModelOverride(modelOverridePath: String?) throws -> ModelOverride? {
@@ -89,15 +90,15 @@ private func startCodeGeneration(
         httpClientConfiguration: HttpClientConfiguration,
         baseName: String, baseFilePath: String,
         applicationDescription: String, applicationSuffix: String,
-        modelFilePath: String, generationType: GenerationType,
+        modelFilePath: String, modelFormat: ModelFormat,
+        generationType: GenerationType,
         asyncAwait: AsyncAwaitCodeGenParameters,
         eventLoopFutureOperationHandlers: CodeGenFeatureStatus,
         initializationType: InitializationType,
         testDiscovery: CodeGenFeatureStatus,
         mainAnnotation: CodeGenFeatureStatus,
         operationStubGenerationRule: OperationStubGenerationRule,
-        modelOverride: ModelOverride?,
-        swaggerFileVersion: Int) throws -> ServiceModel {
+        modelOverride: ModelOverride?) throws -> ServiceModel {
     let validationErrorDeclaration = ErrorDeclaration.external(
         libraryImport: "SmokeOperations",
         errorType: "SmokeOperationsError")
@@ -117,7 +118,8 @@ private func startCodeGeneration(
         applicationDescription: applicationDescription,
         applicationSuffix: applicationSuffix)
     
-    if swaggerFileVersion == 3 {
+    switch modelFormat {
+    case .openAPI30:
         return try SmokeFrameworkCodeGeneration.generateFromModel(
             modelFilePath: modelFilePath,
             modelType: OpenAPIServiceModel.self,
@@ -132,7 +134,7 @@ private func startCodeGeneration(
             mainAnnotation: mainAnnotation,
             asyncInitialization: asyncAwait.asyncInitialization,
             modelOverride: modelOverride)
-    } else if swaggerFileVersion == 2 {
+    case .swagger:
         return try SmokeFrameworkCodeGeneration.generateFromModel(
             modelFilePath: modelFilePath,
             modelType: SwaggerServiceModel.self,
@@ -147,8 +149,6 @@ private func startCodeGeneration(
             mainAnnotation: mainAnnotation,
             asyncInitialization: asyncAwait.asyncInitialization,
             modelOverride: modelOverride)
-    } else {
-        fatalError("Invalid swagger version.")
     }
 }
 
@@ -192,9 +192,11 @@ func handleApplication(parameters: Parameters) throws {
     
     let model = try startCodeGeneration(
         httpClientConfiguration: httpClientConfiguration,
-        baseName: parameters.baseName, baseFilePath: parameters.baseFilePath,
+        baseName: parameters.baseName,
+        baseFilePath: parameters.baseOutputFilePath ?? parameters.baseFilePath,
         applicationDescription: applicationDescription,
-        applicationSuffix: applicationSuffix, modelFilePath: parameters.modelFilePath,
+        applicationSuffix: applicationSuffix,
+        modelFilePath: parameters.modelFilePath, modelFormat: parameters.modelFormat ?? .swagger,
         generationType: parameters.generationType,
         asyncAwait: parameters.asyncAwait ?? .default,
         eventLoopFutureOperationHandlers: parameters.eventLoopFutureOperationHandlers ?? .disabled,
@@ -202,7 +204,7 @@ func handleApplication(parameters: Parameters) throws {
         testDiscovery: parameters.testDiscovery ?? .disabled,
         mainAnnotation: parameters.mainAnnotation ?? .disabled,
         operationStubGenerationRule: parameters.operationStubGenerationRule,
-        modelOverride: modelOverride, swaggerFileVersion: parameters.swaggerFileVersion)
+        modelOverride: modelOverride)
     
     if (parameters.generateCodeGenConfig ?? false) {
         let parameterModelFilePath = parameters.modelFilePath
@@ -219,7 +221,7 @@ func handleApplication(parameters: Parameters) throws {
         
         let existingOperations = Array(model.operationDescriptions.keys)
         
-        let smokeFrameworkCodeGen = SmokeFrameworkCodeGen(modelFilePath: modelFilePath,
+        let smokeFrameworkCodeGen = SmokeFrameworkCodeGen(modelFilePath: modelFilePath, modelFormat: parameters.modelFormat,
                                                           baseName: parameters.baseName,
                                                           applicationSuffix: parameters.applicationSuffix,
                                                           generationType: .serverUpdate,
@@ -269,8 +271,11 @@ struct SmokeFrameworkApplicationGenerateCommand: ParsableCommand {
     @Option(name: .customLong("application-suffix"), help: "The suffix for the generated executable. [Service]")
     var applicationSuffix: String?
     
-    @Option(name: .customLong("base-file-path"), help: "The file path to place the root of the generated Swift package.")
+    @Option(name: .customLong("base-file-path"), help: "The file path to the root of the input Swift package.")
     var baseFilePath: String
+    
+    @Option(name: .customLong("base-output-file-path"), help: "The file path to place the root of the generated Swift package.")
+    var baseOutputFilePath: String?
     
     @Option(name: .customLong("generation-type"), help: "What code to generate. (server|serverUpdate)")
     var generationType: GenerationType?
@@ -383,18 +388,26 @@ struct SmokeFrameworkApplicationGenerateCommand: ParsableCommand {
             operationStubGenerationRule = .allStandaloneFunctions
         }
         
-        let theSwaggerVersion: Int
+        let theModelFormat: ModelFormat?
         if let versionOverride = version {
-            theSwaggerVersion = versionOverride
+            if versionOverride == 2 {
+                theModelFormat = .swagger
+            } else if versionOverride == 3 {
+                theModelFormat = .openAPI30
+            } else {
+                fatalError("Unsupported swagger version '\(versionOverride)'.")
+            }
         } else {
-            theSwaggerVersion = 2
+            theModelFormat = config?.modelFormat
         }
         
         let parameters = Parameters(
             modelFilePath: theModelFilePath,
+            modelFormat: theModelFormat,
             baseName: theBaseName,
             applicationSuffix: theApplicationSuffix,
             baseFilePath: baseFilePath,
+            baseOutputFilePath: baseOutputFilePath,
             generationType: theGenerationType,
             applicationDescription: theApplicationDescription,
             modelOverride: modelOverride,
@@ -405,8 +418,7 @@ struct SmokeFrameworkApplicationGenerateCommand: ParsableCommand {
             initializationType: config?.initializationType,
             testDiscovery: config?.testDiscovery,
             mainAnnotation: config?.mainAnnotation,
-            operationStubGenerationRule: operationStubGenerationRule,
-            swaggerFileVersion: theSwaggerVersion)
+            operationStubGenerationRule: operationStubGenerationRule)
         
         try handleApplication(parameters: parameters)
     }

--- a/Sources/SmokeFrameworkApplicationGenerate/main.swift
+++ b/Sources/SmokeFrameworkApplicationGenerate/main.swift
@@ -132,7 +132,7 @@ private func startCodeGeneration(
             initializationType: initializationType,
             testDiscovery: testDiscovery,
             mainAnnotation: mainAnnotation,
-            asyncInitialization: asyncAwait.asyncInitialization,
+            asyncInitialization: asyncAwait.asyncInitialization ?? .disabled,
             modelOverride: modelOverride)
     case .swagger:
         return try SmokeFrameworkCodeGeneration.generateFromModel(
@@ -147,7 +147,7 @@ private func startCodeGeneration(
             initializationType: initializationType,
             testDiscovery: testDiscovery,
             mainAnnotation: mainAnnotation,
-            asyncInitialization: asyncAwait.asyncInitialization,
+            asyncInitialization: asyncAwait.asyncInitialization ?? .disabled,
             modelOverride: modelOverride)
     }
 }

--- a/Sources/SmokeFrameworkCodeGeneration/ServiceModelCodeGenerator+generateHandlerSelector.swift
+++ b/Sources/SmokeFrameworkCodeGeneration/ServiceModelCodeGenerator+generateHandlerSelector.swift
@@ -31,6 +31,8 @@ extension ServiceModelCodeGenerator {
         let baseName = applicationDescription.baseName
         let baseFilePath = applicationDescription.baseFilePath
         
+        
+        
         addGeneratedFileHeader(fileBuilder: fileBuilder)
         
         // build a map of http url to operation handler
@@ -44,15 +46,17 @@ extension ServiceModelCodeGenerator {
             import \(baseName)Operations
             import SmokeOperations
             import SmokeOperationsHTTP1
-
             """)
         
-        if eventLoopFutureOperationHandlers == .enabled {
+        switch eventLoopFutureOperationHandlers {
+        case .enabled:
             fileBuilder.appendLine("""
                 import SmokeAsyncHTTP1
+
                 """)
-        } else {
+        case .disabled:
             fileBuilder.appendLine("""
+
                 """)
         }
         

--- a/Sources/SmokeFrameworkCodeGeneration/ServiceModelCodeGenerator+generatePerInvocationContextInitializer.swift
+++ b/Sources/SmokeFrameworkCodeGeneration/ServiceModelCodeGenerator+generatePerInvocationContextInitializer.swift
@@ -129,9 +129,6 @@ extension ServiceModelCodeGenerator {
     private func generateStreamlinedOperationsContextGenerator(generationType: GenerationType,
                                                                mainAnnotation: CodeGenFeatureStatus,
                                                                asyncInitialization: CodeGenFeatureStatus) {
-        generateStreamlinedOperationsContextProtocolGenerator(generationType: generationType,
-                                                              asyncInitialization: asyncInitialization)
-        
         let fileBuilder = FileBuilder()
         let baseName = applicationDescription.baseName
         let baseFilePath = applicationDescription.baseFilePath
@@ -169,6 +166,14 @@ extension ServiceModelCodeGenerator {
                 """)
         }
         
+        let asyncPrefix: String
+        switch asyncInitialization {
+        case .disabled:
+            asyncPrefix = ""
+        case .enabled:
+            asyncPrefix = "async "
+        }
+        
         fileBuilder.appendLine("""
             struct \(baseName)PerInvocationContextInitializer: \(baseName)PerInvocationContextInitializerProtocol {
                 // TODO: Add properties to be accessed by the operation handlers
@@ -176,7 +181,7 @@ extension ServiceModelCodeGenerator {
                 /**
                  On application startup.
                  */
-                init(eventLoopGroup: EventLoopGroup) throws {
+                init(eventLoopGroup: EventLoopGroup) \(asyncPrefix)throws {
                     CloudwatchStandardErrorLogger.enableLogging()
             
                     // TODO: Add additional application initialization
@@ -193,7 +198,7 @@ extension ServiceModelCodeGenerator {
                 /**
                  On application shutdown.
                 */
-                func onShutdown() throws {
+                func onShutdown() \(asyncPrefix)throws {
                     
                 }
             }
@@ -202,9 +207,8 @@ extension ServiceModelCodeGenerator {
         fileBuilder.write(toFile: fileName, atFilePath: filePath)
     }
     
-    private func generateStreamlinedOperationsContextProtocolGenerator(generationType: GenerationType,
-                                                                       asyncInitialization: CodeGenFeatureStatus) {
-        
+    public func generateStreamlinedOperationsContextProtocolGenerator(generationType: GenerationType,
+                                                                      asyncInitialization: CodeGenFeatureStatus) {
         let fileBuilder = FileBuilder()
         let baseName = applicationDescription.baseName
         let baseFilePath = applicationDescription.baseFilePath

--- a/Sources/SmokeFrameworkCodeGeneration/ServiceModelCodeGenerator+generateServerApplicationFiles.swift
+++ b/Sources/SmokeFrameworkCodeGeneration/ServiceModelCodeGenerator+generateServerApplicationFiles.swift
@@ -24,12 +24,11 @@ extension ServiceModelCodeGenerator {
      Generate the main Swift file for the generated application as a Container Server.
      */
     func generateServerApplicationFiles(generationType: GenerationType,
-                                        asyncOperationStubs: CodeGenFeatureStatus,
                                         mainAnnotation: CodeGenFeatureStatus) {
         if case .disabled = mainAnnotation {
             generateContainerServerApplicationMain(generationType: generationType)
         }
-        generatePackageFile(generationType: generationType, asyncOperationStubs: asyncOperationStubs)
+        generatePackageFile(generationType: generationType)
         generateLintFile(generationType: generationType)
         generateGitIgnoreFile(generationType: generationType)
     }
@@ -65,8 +64,7 @@ extension ServiceModelCodeGenerator {
         fileBuilder.write(toFile: fileName, atFilePath: filePath)
     }
 
-    private func generatePackageFile(generationType: GenerationType,
-                                     asyncOperationStubs: CodeGenFeatureStatus) {
+    private func generatePackageFile(generationType: GenerationType) {
         
         let fileBuilder = FileBuilder()
         let baseName = applicationDescription.baseName
@@ -81,17 +79,6 @@ extension ServiceModelCodeGenerator {
             }
         }
         
-        let macOSVersion: String
-        let iOSVersion: String
-        switch asyncOperationStubs {
-        case .disabled:
-            macOSVersion = ".v10_15"
-            iOSVersion = ".v10"
-        case .enabled:
-            macOSVersion = ".v12"
-            iOSVersion = ".v15"
-        }
-        
         fileBuilder.appendLine("""
             // swift-tools-version:5.5
             // The swift-tools-version declares the minimum version of Swift required to build this package.
@@ -101,7 +88,7 @@ extension ServiceModelCodeGenerator {
             let package = Package(
                 name: "\(baseName)",
                 platforms: [
-                  .macOS(\(macOSVersion)), .iOS(\(iOSVersion))
+                  .macOS(.v10_15), .iOS(.v10)
                 ],
                 products: [
                     // Products define the executables and libraries produced by a package, and make them visible to other packages.

--- a/Tests/CodeGenerateTests/CodeGenerateTests.swift
+++ b/Tests/CodeGenerateTests/CodeGenerateTests.swift
@@ -8,9 +8,4 @@ class CodeGenerateTests: XCTestCase {
     func executionPlanServiceGenerate() {
         
     }
-
-    static var allTests = [
-        ("testExample", testExample),
-        ("executionPlanServiceGenerate", executionPlanServiceGenerate)
-    ]
 }

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -1,6 +1,0 @@
-import XCTest
-@testable import CodeGenerateTests
-
-XCTMain([
-    testCase(CodeGenerateTests.allTests),
-])


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
1. Support generator as SPM plugin, retaining support for Swift 5.4 and Swift5.5 without the plugin support. 
2. Add option in configuration file for a OpenAPI 3.0 model.
3. Generate async initialisation and shutdown methods when async initialisation is enabled.
4. Make asyncInitialization optional in the smoke-framework-codegen.json config file. This doesn't change any behaviour but addresses a breaking change introduced in https://github.com/amzn/smoke-framework-application-generate/pull/28.
5. Fix spacing around the SmokeAsyncHTTP1 import.

Tested with changes[1] in to EmptyExampleService in smoke-framework-examples which compile[2].

[1] https://github.com/amzn/smoke-framework-examples/commit/5b539614d1f5e5aad3fcac9e876d22140ce66e55
[2] https://github.com/amzn/smoke-framework-examples/pull/15


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
