### PR TITLE
Add additional generator options.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 build
 .DS_Store
 .build/
-.swiftpm/
 *.xcodeproj
+.swift-version
+.swiftpm/
 *~
+.vscode/

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,61 +1,59 @@
 {
-  "object": {
-    "pins": [
-      {
-        "package": "OpenAPIKit",
-        "repositoryURL": "https://github.com/mattpolzin/OpenAPIKit.git",
-        "state": {
-          "branch": null,
-          "revision": "0c668112f9803c1858ed070f9e8ce84922a0b41f",
-          "version": "3.0.0-alpha.4"
-        }
-      },
-      {
-        "package": "ServiceModelSwiftCodeGenerate",
-        "repositoryURL": "https://github.com/amzn/service-model-swift-code-generate.git",
-        "state": {
-          "branch": null,
-          "revision": "286181816fccc2b6ec92049ba68426d08cbe0059",
-          "version": "3.0.0-beta.1"
-        }
-      },
-      {
-        "package": "SmokeAWSGenerate",
-        "repositoryURL": "https://github.com/amzn/smoke-aws-generate.git",
-        "state": {
-          "branch": null,
-          "revision": "2d2902403408d4c7a9f6c69c90975cc048759f95",
-          "version": "3.0.0-beta.1"
-        }
-      },
-      {
-        "package": "SwaggerParser",
-        "repositoryURL": "https://github.com/tachyonics/SwaggerParser.git",
-        "state": {
-          "branch": null,
-          "revision": "c0eb70485c59a9d7dd6765dcd303b49fdb3040ee",
-          "version": "0.6.4"
-        }
-      },
-      {
-        "package": "swift-argument-parser",
-        "repositoryURL": "https://github.com/apple/swift-argument-parser",
-        "state": {
-          "branch": null,
-          "revision": "6b2aa2748a7881eebb9f84fb10c01293e15b52ca",
-          "version": "0.5.0"
-        }
-      },
-      {
-        "package": "Yams",
-        "repositoryURL": "https://github.com/jpsim/Yams.git",
-        "state": {
-          "branch": null,
-          "revision": "9ff1cc9327586db4e0c8f46f064b6a82ec1566fa",
-          "version": "4.0.6"
-        }
+  "pins" : [
+    {
+      "identity" : "openapikit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/mattpolzin/OpenAPIKit.git",
+      "state" : {
+        "revision" : "0c668112f9803c1858ed070f9e8ce84922a0b41f",
+        "version" : "3.0.0-alpha.4"
       }
-    ]
-  },
-  "version": 1
+    },
+    {
+      "identity" : "service-model-swift-code-generate",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/amzn/service-model-swift-code-generate.git",
+      "state" : {
+        "branch" : "main",
+        "revision" : "ed2c9497e0e596b9b1ef40b12a219436c88a2ea6"
+      }
+    },
+    {
+      "identity" : "smoke-aws-generate",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/amzn/smoke-aws-generate.git",
+      "state" : {
+        "branch" : "main",
+        "revision" : "4a4a01557c23cd5d205ee0202be75587d48635c8"
+      }
+    },
+    {
+      "identity" : "swaggerparser",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/tachyonics/SwaggerParser.git",
+      "state" : {
+        "revision" : "c0eb70485c59a9d7dd6765dcd303b49fdb3040ee",
+        "version" : "0.6.4"
+      }
+    },
+    {
+      "identity" : "swift-argument-parser",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-argument-parser",
+      "state" : {
+        "revision" : "6b2aa2748a7881eebb9f84fb10c01293e15b52ca",
+        "version" : "0.5.0"
+      }
+    },
+    {
+      "identity" : "yams",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/jpsim/Yams.git",
+      "state" : {
+        "revision" : "9ff1cc9327586db4e0c8f46f064b6a82ec1566fa",
+        "version" : "4.0.6"
+      }
+    }
+  ],
+  "version" : 2
 }

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,59 +1,61 @@
 {
-  "pins" : [
-    {
-      "identity" : "openapikit",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/mattpolzin/OpenAPIKit.git",
-      "state" : {
-        "revision" : "0c668112f9803c1858ed070f9e8ce84922a0b41f",
-        "version" : "3.0.0-alpha.4"
+  "object": {
+    "pins": [
+      {
+        "package": "OpenAPIKit",
+        "repositoryURL": "https://github.com/mattpolzin/OpenAPIKit.git",
+        "state": {
+          "branch": null,
+          "revision": "0c668112f9803c1858ed070f9e8ce84922a0b41f",
+          "version": "3.0.0-alpha.4"
+        }
+      },
+      {
+        "package": "ServiceModelSwiftCodeGenerate",
+        "repositoryURL": "https://github.com/amzn/service-model-swift-code-generate.git",
+        "state": {
+          "branch": "main",
+          "revision": "4c0ccda7df61c87538df34fc47982435c4a52206",
+          "version": null
+        }
+      },
+      {
+        "package": "SmokeAWSGenerate",
+        "repositoryURL": "https://github.com/amzn/smoke-aws-generate.git",
+        "state": {
+          "branch": "main",
+          "revision": "4a4a01557c23cd5d205ee0202be75587d48635c8",
+          "version": null
+        }
+      },
+      {
+        "package": "SwaggerParser",
+        "repositoryURL": "https://github.com/tachyonics/SwaggerParser.git",
+        "state": {
+          "branch": null,
+          "revision": "c0eb70485c59a9d7dd6765dcd303b49fdb3040ee",
+          "version": "0.6.4"
+        }
+      },
+      {
+        "package": "swift-argument-parser",
+        "repositoryURL": "https://github.com/apple/swift-argument-parser",
+        "state": {
+          "branch": null,
+          "revision": "6b2aa2748a7881eebb9f84fb10c01293e15b52ca",
+          "version": "0.5.0"
+        }
+      },
+      {
+        "package": "Yams",
+        "repositoryURL": "https://github.com/jpsim/Yams.git",
+        "state": {
+          "branch": null,
+          "revision": "9ff1cc9327586db4e0c8f46f064b6a82ec1566fa",
+          "version": "4.0.6"
+        }
       }
-    },
-    {
-      "identity" : "service-model-swift-code-generate",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/amzn/service-model-swift-code-generate.git",
-      "state" : {
-        "branch" : "main",
-        "revision" : "ed2c9497e0e596b9b1ef40b12a219436c88a2ea6"
-      }
-    },
-    {
-      "identity" : "smoke-aws-generate",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/amzn/smoke-aws-generate.git",
-      "state" : {
-        "branch" : "main",
-        "revision" : "4a4a01557c23cd5d205ee0202be75587d48635c8"
-      }
-    },
-    {
-      "identity" : "swaggerparser",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/tachyonics/SwaggerParser.git",
-      "state" : {
-        "revision" : "c0eb70485c59a9d7dd6765dcd303b49fdb3040ee",
-        "version" : "0.6.4"
-      }
-    },
-    {
-      "identity" : "swift-argument-parser",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-argument-parser",
-      "state" : {
-        "revision" : "6b2aa2748a7881eebb9f84fb10c01293e15b52ca",
-        "version" : "0.5.0"
-      }
-    },
-    {
-      "identity" : "yams",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/jpsim/Yams.git",
-      "state" : {
-        "revision" : "9ff1cc9327586db4e0c8f46f064b6a82ec1566fa",
-        "version" : "4.0.6"
-      }
-    }
-  ],
-  "version" : 2
+    ]
+  },
+  "version": 1
 }

--- a/Package.swift
+++ b/Package.swift
@@ -38,8 +38,8 @@ let package = Package(
             targets: ["SmokeFrameworkGenerateHttp1"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/amzn/smoke-aws-generate.git", from: "3.0.0-beta.1"),
-        .package(url: "https://github.com/amzn/service-model-swift-code-generate.git", from: "3.0.0-beta.1"),
+        .package(url: "https://github.com/amzn/smoke-aws-generate.git", branch: "main"),
+        .package(url: "https://github.com/amzn/service-model-swift-code-generate.git", branch: "main"),
         .package(url: "https://github.com/apple/swift-argument-parser", from: "0.3.0"),
     ],
     targets: [

--- a/Package@swift-5.4.swift
+++ b/Package@swift-5.4.swift
@@ -30,9 +30,9 @@ let package = Package(
     ],
     dependencies: [
         .package(name: "SmokeAWSGenerate",
-                 url: "https://github.com/amzn/smoke-aws-generate.git", from: "3.0.0-beta.1"),
+                 url: "https://github.com/amzn/smoke-aws-generate.git", .branch("main")),
         .package(name: "ServiceModelSwiftCodeGenerate",
-                 url: "https://github.com/amzn/service-model-swift-code-generate.git", from: "3.0.0-beta.1"),
+                 url: "https://github.com/amzn/service-model-swift-code-generate.git", .branch("main")),
         .package(url: "https://github.com/apple/swift-argument-parser", from: "0.3.0"),
     ],
     targets: [

--- a/Package@swift-5.5.swift
+++ b/Package@swift-5.5.swift
@@ -30,9 +30,9 @@ let package = Package(
     ],
     dependencies: [
         .package(name: "SmokeAWSGenerate",
-                 url: "https://github.com/amzn/smoke-aws-generate.git", from: "3.0.0-beta.1"),
+                 url: "https://github.com/amzn/smoke-aws-generate.git", .branch("main")),
         .package(name: "ServiceModelSwiftCodeGenerate",
-                 url: "https://github.com/amzn/service-model-swift-code-generate.git", from: "3.0.0-beta.1"),
+                 url: "https://github.com/amzn/service-model-swift-code-generate.git", .branch("main")),
         .package(url: "https://github.com/apple/swift-argument-parser", from: "0.3.0"),
     ],
     targets: [

--- a/Sources/SmokeFrameworkApplicationGenerate/SmokeFrameworkCodeGen.swift
+++ b/Sources/SmokeFrameworkApplicationGenerate/SmokeFrameworkCodeGen.swift
@@ -38,5 +38,9 @@ struct SmokeFrameworkCodeGen: Codable {
     let initializationType: InitializationType?
     let testDiscovery: CodeGenFeatureStatus?
     let mainAnnotation: CodeGenFeatureStatus?
+    let addSendableConformance: CodeGenFeatureStatus?
+    let eventLoopFutureClientAPIs: CodeGenFeatureStatus?
+    let minimumCompilerSupport: MinimumCompilerSupport?
+    let clientConfigurationType: ClientConfigurationType?
     let operationStubGenerationRule: OperationStubGenerationRule
 }

--- a/Sources/SmokeFrameworkApplicationGenerate/main.swift
+++ b/Sources/SmokeFrameworkApplicationGenerate/main.swift
@@ -47,6 +47,10 @@ struct Parameters {
     var initializationType: InitializationType?
     var testDiscovery: CodeGenFeatureStatus?
     var mainAnnotation: CodeGenFeatureStatus?
+    var addSendableConformance: CodeGenFeatureStatus?
+    var eventLoopFutureClientAPIs: CodeGenFeatureStatus?
+    var minimumCompilerSupport: MinimumCompilerSupport?
+    var clientConfigurationType: ClientConfigurationType?
     var operationStubGenerationRule: OperationStubGenerationRule
 }
 
@@ -97,6 +101,10 @@ private func startCodeGeneration(
         initializationType: InitializationType,
         testDiscovery: CodeGenFeatureStatus,
         mainAnnotation: CodeGenFeatureStatus,
+        addSendableConformance: CodeGenFeatureStatus,
+        eventLoopFutureClientAPIs: CodeGenFeatureStatus,
+        minimumCompilerSupport: MinimumCompilerSupport,
+        clientConfigurationType: ClientConfigurationType,
         operationStubGenerationRule: OperationStubGenerationRule,
         modelOverride: ModelOverride?) throws -> ServiceModel {
     let validationErrorDeclaration = ErrorDeclaration.external(
@@ -107,6 +115,10 @@ private func startCodeGeneration(
         validationErrorDeclaration: validationErrorDeclaration,
         unrecognizedErrorDeclaration: unrecognizedErrorDeclaration,
         asyncAwaitAPIs: asyncAwait.clientAPIs,
+        eventLoopFutureClientAPIs: eventLoopFutureClientAPIs,
+        addSendableConformance: addSendableConformance,
+        minimumCompilerSupport: minimumCompilerSupport,
+        clientConfigurationType: clientConfigurationType,
         generateModelShapeConversions: true,
         optionalsInitializeEmpty: true,
         fileHeader: nil,
@@ -203,6 +215,10 @@ func handleApplication(parameters: Parameters) throws {
         initializationType: parameters.initializationType ?? .original,
         testDiscovery: parameters.testDiscovery ?? .disabled,
         mainAnnotation: parameters.mainAnnotation ?? .disabled,
+        addSendableConformance: parameters.addSendableConformance ?? .disabled,
+        eventLoopFutureClientAPIs: parameters.eventLoopFutureClientAPIs ?? .enabled,
+        minimumCompilerSupport: parameters.minimumCompilerSupport ?? .unknown,
+        clientConfigurationType: parameters.clientConfigurationType ?? .generator,
         operationStubGenerationRule: parameters.operationStubGenerationRule,
         modelOverride: modelOverride)
     
@@ -233,6 +249,10 @@ func handleApplication(parameters: Parameters) throws {
                                                           initializationType: parameters.initializationType,
                                                           testDiscovery: parameters.testDiscovery,
                                                           mainAnnotation: parameters.mainAnnotation,
+                                                          addSendableConformance: parameters.addSendableConformance,
+                                                          eventLoopFutureClientAPIs: parameters.eventLoopFutureClientAPIs,
+                                                          minimumCompilerSupport: parameters.minimumCompilerSupport,
+                                                          clientConfigurationType: parameters.clientConfigurationType,
                                                           operationStubGenerationRule: .allFunctionsWithinContextExceptStandaloneFunctionsFor(existingOperations.sorted(by: <)))
         
         let jsonEncoder = JSONEncoder()
@@ -418,6 +438,10 @@ struct SmokeFrameworkApplicationGenerateCommand: ParsableCommand {
             initializationType: config?.initializationType,
             testDiscovery: config?.testDiscovery,
             mainAnnotation: config?.mainAnnotation,
+            addSendableConformance: config?.addSendableConformance,
+            eventLoopFutureClientAPIs: config?.eventLoopFutureClientAPIs,
+            minimumCompilerSupport: config?.minimumCompilerSupport,
+            clientConfigurationType: config?.clientConfigurationType,
             operationStubGenerationRule: operationStubGenerationRule)
         
         try handleApplication(parameters: parameters)

--- a/Sources/SmokeFrameworkCodeGeneration/ServiceModelCodeGenerator+generateOperationsContext.swift
+++ b/Sources/SmokeFrameworkCodeGeneration/ServiceModelCodeGenerator+generateOperationsContext.swift
@@ -37,6 +37,15 @@ extension ServiceModelCodeGenerator {
             }
         }
         
+        var conformingProtocols: [String] = []
+        var conformancePadding: String = ""
+        if case .enabled = self.customizations.addSendableConformance {
+            conformingProtocols.append("Sendable")
+            conformancePadding = " "
+        }
+        
+        let conformingProtocolsString = conformingProtocols.joined(separator: ", ")
+        
         fileBuilder.appendLine("""
             //
             // \(baseName)OperationsContext.swift
@@ -49,7 +58,7 @@ extension ServiceModelCodeGenerator {
             /**
              The context to be passed to each of the \(baseName) operations.
              */
-            public struct \(baseName)OperationsContext {
+            public struct \(baseName)OperationsContext \(conformingProtocolsString)\(conformancePadding){
                 let logger: Logger
                 // TODO: Add properties to be accessed by the operation handlers
             


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Add additional generator options.
1. addSendableConformance: If Sendable conformance should be added to model types. Defaults to disabled.
2. eventLoopFutureClientAPIs: If EventLoopFuture-returning APIs should be generated. Defaults to enabled.
3. minimumCompilerSupport: The minimum compiler version support required for the generated code. Defaults to unknown.
4. clientConfigurationType: If a generator or configuration + operations client types should be generated. Defaults to a generator type.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
