### PR TITLE
Support specifying integration-specific context type names.

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/amzn/service-model-swift-code-generate.git",
         "state": {
           "branch": null,
-          "revision": "4c0ccda7df61c87538df34fc47982435c4a52206",
-          "version": "3.0.0-beta.5"
+          "revision": "cf4aa31478c296f3afeafffdbe14ae5bfbc99593",
+          "version": "3.0.0-beta.11"
         }
       },
       {
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/amzn/smoke-aws-generate.git",
         "state": {
           "branch": null,
-          "revision": "d71519da40a2058ea2188f35a7cbd3082534a97e",
-          "version": "3.0.0-beta.3"
+          "revision": "fc01b7d4a0222df636a1a9ff8827a0159fef52bd",
+          "version": "3.0.0-beta.7"
         }
       },
       {

--- a/Sources/SmokeFrameworkApplicationGenerate/SmokeFrameworkCodeGen.swift
+++ b/Sources/SmokeFrameworkApplicationGenerate/SmokeFrameworkCodeGen.swift
@@ -30,6 +30,7 @@ struct SmokeFrameworkCodeGen: Codable {
     let baseName: String
     let applicationSuffix: String?
     let generationType: GenerationType
+    let integrations: ServiceIntegrations?
     let applicationDescription: String?
     let modelOverride: ModelOverride?
     let httpClientConfiguration: HttpClientConfiguration?

--- a/Sources/SmokeFrameworkApplicationGenerate/main.swift
+++ b/Sources/SmokeFrameworkApplicationGenerate/main.swift
@@ -38,6 +38,7 @@ struct Parameters {
     var baseFilePath: String
     var baseOutputFilePath: String?
     var generationType: GenerationType
+    var integrations: ServiceIntegrations?
     var applicationDescription: String?
     var modelOverride: ConfigurationProvider<ModelOverride>?
     var generateCodeGenConfig: Bool?
@@ -96,6 +97,7 @@ private func startCodeGeneration(
         applicationDescription: String, applicationSuffix: String,
         modelFilePath: String, modelFormat: ModelFormat,
         generationType: GenerationType,
+        integrations: ServiceIntegrations?,
         asyncAwait: AsyncAwaitCodeGenParameters,
         eventLoopFutureOperationHandlers: CodeGenFeatureStatus,
         initializationType: InitializationType,
@@ -135,7 +137,7 @@ private func startCodeGeneration(
         return try SmokeFrameworkCodeGeneration.generateFromModel(
             modelFilePath: modelFilePath,
             modelType: OpenAPIServiceModel.self,
-            generationType: generationType,
+            generationType: generationType, integrations: integrations,
             customizations: customizations,
             applicationDescription: fullApplicationDescription,
             operationStubGenerationRule: operationStubGenerationRule,
@@ -150,7 +152,7 @@ private func startCodeGeneration(
         return try SmokeFrameworkCodeGeneration.generateFromModel(
             modelFilePath: modelFilePath,
             modelType: SwaggerServiceModel.self,
-            generationType: generationType,
+            generationType: generationType, integrations: integrations,
             customizations: customizations,
             applicationDescription: fullApplicationDescription,
             operationStubGenerationRule: operationStubGenerationRule,
@@ -210,6 +212,7 @@ func handleApplication(parameters: Parameters) throws {
         applicationSuffix: applicationSuffix,
         modelFilePath: parameters.modelFilePath, modelFormat: parameters.modelFormat ?? .swagger,
         generationType: parameters.generationType,
+        integrations: parameters.integrations,
         asyncAwait: parameters.asyncAwait ?? .default,
         eventLoopFutureOperationHandlers: parameters.eventLoopFutureOperationHandlers ?? .disabled,
         initializationType: parameters.initializationType ?? .original,
@@ -241,6 +244,7 @@ func handleApplication(parameters: Parameters) throws {
                                                           baseName: parameters.baseName,
                                                           applicationSuffix: parameters.applicationSuffix,
                                                           generationType: .serverUpdate,
+                                                          integrations: parameters.integrations,
                                                           applicationDescription: parameters.applicationDescription,
                                                           modelOverride: modelOverride,
                                                           httpClientConfiguration: httpClientConfigurationOptional,
@@ -429,6 +433,7 @@ struct SmokeFrameworkApplicationGenerateCommand: ParsableCommand {
             baseFilePath: baseFilePath,
             baseOutputFilePath: baseOutputFilePath,
             generationType: theGenerationType,
+            integrations: config?.integrations,
             applicationDescription: theApplicationDescription,
             modelOverride: modelOverride,
             generateCodeGenConfig: generateCodeGenConfig ?? false,

--- a/Sources/SmokeFrameworkCodeGeneration/ServiceModelCodeGenerator+generateHandlerSelector.swift
+++ b/Sources/SmokeFrameworkCodeGeneration/ServiceModelCodeGenerator+generateHandlerSelector.swift
@@ -25,6 +25,7 @@ extension ServiceModelCodeGenerator {
      */
     func generateServerHanderSelector(operationStubGenerationRule: OperationStubGenerationRule,
                                       initializationType: InitializationType,
+                                      contextTypeName: String,
                                       eventLoopFutureOperationHandlers: CodeGenFeatureStatus) {
         
         let fileBuilder = FileBuilder()
@@ -69,14 +70,14 @@ extension ServiceModelCodeGenerator {
         case .original:
             fileBuilder.appendLine("""
                 public func addOperations<SelectorType: SmokeHTTP1HandlerSelector>(selector: inout SelectorType)
-                    where SelectorType.ContextType == \(baseName)OperationsContext,
+                    where SelectorType.ContextType == \(contextTypeName),
                     SelectorType.OperationIdentifer == \(baseName)ModelOperations {
                 """)
         case .streamlined:
             fileBuilder.appendLine("""
                 public extension \(baseName)ModelOperations {
                     static func addToSmokeServer<SelectorType: SmokeHTTP1HandlerSelector>(selector: inout SelectorType)
-                        where SelectorType.ContextType == \(baseName)OperationsContext,
+                        where SelectorType.ContextType == \(contextTypeName),
                         SelectorType.OperationIdentifer == \(baseName)ModelOperations {
                 """)
             fileBuilder.incIndent()

--- a/Sources/SmokeFrameworkCodeGeneration/ServiceModelCodeGenerator+generatePerInvocationContextInitializer.swift
+++ b/Sources/SmokeFrameworkCodeGeneration/ServiceModelCodeGenerator+generatePerInvocationContextInitializer.swift
@@ -23,19 +23,25 @@ extension ServiceModelCodeGenerator {
      Generate the stub operations context generator for the generated application.
      */
     func generateOperationsContextGenerator(generationType: GenerationType,
+                                            contextTypeName: String,
                                             initializationType: InitializationType,
                                             mainAnnotation: CodeGenFeatureStatus,
                                             asyncInitialization: CodeGenFeatureStatus) {
         switch initializationType {
         case .original:
-            generateOriginalOperationsContextGenerator(generationType: generationType, mainAnnotation: mainAnnotation)
+            generateOriginalOperationsContextGenerator(generationType: generationType,
+                                                       contextTypeName: contextTypeName,
+                                                       mainAnnotation: mainAnnotation)
         case .streamlined:
-            generateStreamlinedOperationsContextGenerator(generationType: generationType, mainAnnotation: mainAnnotation,
+            generateStreamlinedOperationsContextGenerator(generationType: generationType,
+                                                          contextTypeName: contextTypeName,
+                                                          mainAnnotation: mainAnnotation,
                                                           asyncInitialization: asyncInitialization)
         }
     }
     
     private func generateOriginalOperationsContextGenerator(generationType: GenerationType,
+                                                            contextTypeName: String,
                                                             mainAnnotation: CodeGenFeatureStatus) {
         
         let fileBuilder = FileBuilder()
@@ -83,7 +89,7 @@ extension ServiceModelCodeGenerator {
         fileBuilder.appendLine("""
             struct \(baseName)PerInvocationContextInitializer: SmokeServerPerInvocationContextInitializer {
                 typealias SelectorType =
-                    StandardSmokeHTTP1HandlerSelector<\(baseName)OperationsContext, \(baseName)OperationDelegate,
+                    StandardSmokeHTTP1HandlerSelector<\(contextTypeName), \(baseName)OperationDelegate,
                                                       \(baseName)ModelOperations>
             
                 let handlerSelector: SelectorType
@@ -106,8 +112,8 @@ extension ServiceModelCodeGenerator {
                  On invocation.
                 */
                 public func getInvocationContext(invocationReporting: SmokeServerInvocationReporting<SmokeInvocationTraceContext>)
-                -> \(baseName)OperationsContext {
-                    return \(baseName)OperationsContext(logger: invocationReporting.logger)
+                -> \(contextTypeName) {
+                    return \(contextTypeName)(logger: invocationReporting.logger)
                 }
             
                 /**
@@ -127,6 +133,7 @@ extension ServiceModelCodeGenerator {
     }
     
     private func generateStreamlinedOperationsContextGenerator(generationType: GenerationType,
+                                                               contextTypeName: String,
                                                                mainAnnotation: CodeGenFeatureStatus,
                                                                asyncInitialization: CodeGenFeatureStatus) {
         let fileBuilder = FileBuilder()
@@ -191,8 +198,8 @@ extension ServiceModelCodeGenerator {
                  On invocation.
                 */
                 public func getInvocationContext(invocationReporting: SmokeServerInvocationReporting<SmokeInvocationTraceContext>)
-                -> \(baseName)OperationsContext {
-                    return \(baseName)OperationsContext(logger: invocationReporting.logger)
+                -> \(contextTypeName) {
+                    return \(contextTypeName)(logger: invocationReporting.logger)
                 }
             
                 /**
@@ -208,6 +215,7 @@ extension ServiceModelCodeGenerator {
     }
     
     public func generateStreamlinedOperationsContextProtocolGenerator(generationType: GenerationType,
+                                                                      contextTypeName: String,
                                                                       asyncInitialization: CodeGenFeatureStatus) {
         let fileBuilder = FileBuilder()
         let baseName = applicationDescription.baseName
@@ -247,7 +255,7 @@ extension ServiceModelCodeGenerator {
              Convenience protocol for the initialization of \(baseName)\(applicationSuffix).
              */
             public protocol \(baseName)PerInvocationContextInitializerProtocol: StandardJSONSmoke\(baseInitializerInfix)ServerPerInvocationContextInitializer
-            where ContextType == \(baseName)OperationsContext, OperationIdentifer == \(baseName)ModelOperations {
+            where ContextType == \(contextTypeName), OperationIdentifer == \(baseName)ModelOperations {
                 init(eventLoopGroup: EventLoopGroup) \(asyncPrefix)throws
             }
             


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Support specifying integration-specific context type names. There are two use cases this change enables-
1. A service wants to avoid using Existential Types in its context. With this change a service can-
  i. define a generic context type[1]
  ii. a non-generic typealias[2] in its integration target
  iii. specify the non-generic typealias[3] as the `contextTypeName`
  iv. then use a context with concrete types at runtime, avoiding the runtime overhead of existentials
  v. specify a context with Mock concrete types[4] for testing
2. A service wants to be able to use a different context type name; for whatever reason the default currently expected by the code generator is not suitable.

[1] https://github.com/amzn/smoke-framework-examples/blob/no_existential_types_example/NoExistentialTypesExampleService/Sources/NoExistentialTypesExampleOperations/NoExistentialTypesExampleOperationsContext.swift#L35
[2] https://github.com/amzn/smoke-framework-examples/blob/no_existential_types_example/NoExistentialTypesExampleService/Sources/NoExistentialTypesExampleOperationsHTTP1/HTTPNoExistentialTypesExampleOperationsContext.swift#L24
[3] https://github.com/amzn/smoke-framework-examples/blob/no_existential_types_example/NoExistentialTypesExampleService/smoke-framework-codegen.json#L8
[4] https://github.com/amzn/smoke-framework-examples/blob/no_existential_types_example/NoExistentialTypesExampleService/Tests/NoExistentialTypesExampleOperationsTests/NoExistentialTypesExampleTestConfiguration.swift#L71


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
