### PR TITLE
Update Smoke AWS Generate to include bug fix for Client Generators

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,59 +1,61 @@
 {
-  "pins" : [
-    {
-      "identity" : "openapikit",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/mattpolzin/OpenAPIKit.git",
-      "state" : {
-        "revision" : "0c668112f9803c1858ed070f9e8ce84922a0b41f",
-        "version" : "3.0.0-alpha.4"
+  "object": {
+    "pins": [
+      {
+        "package": "OpenAPIKit",
+        "repositoryURL": "https://github.com/mattpolzin/OpenAPIKit.git",
+        "state": {
+          "branch": null,
+          "revision": "0c668112f9803c1858ed070f9e8ce84922a0b41f",
+          "version": "3.0.0-alpha.4"
+        }
+      },
+      {
+        "package": "ServiceModelSwiftCodeGenerate",
+        "repositoryURL": "https://github.com/amzn/service-model-swift-code-generate.git",
+        "state": {
+          "branch": null,
+          "revision": "cf4aa31478c296f3afeafffdbe14ae5bfbc99593",
+          "version": "3.0.0-beta.11"
+        }
+      },
+      {
+        "package": "SmokeAWSGenerate",
+        "repositoryURL": "https://github.com/amzn/smoke-aws-generate.git",
+        "state": {
+          "branch": null,
+          "revision": "fc01b7d4a0222df636a1a9ff8827a0159fef52bd",
+          "version": "3.0.0-beta.7"
+        }
+      },
+      {
+        "package": "SwaggerParser",
+        "repositoryURL": "https://github.com/tachyonics/SwaggerParser.git",
+        "state": {
+          "branch": null,
+          "revision": "c0eb70485c59a9d7dd6765dcd303b49fdb3040ee",
+          "version": "0.6.4"
+        }
+      },
+      {
+        "package": "swift-argument-parser",
+        "repositoryURL": "https://github.com/apple/swift-argument-parser",
+        "state": {
+          "branch": null,
+          "revision": "6b2aa2748a7881eebb9f84fb10c01293e15b52ca",
+          "version": "0.5.0"
+        }
+      },
+      {
+        "package": "Yams",
+        "repositoryURL": "https://github.com/jpsim/Yams.git",
+        "state": {
+          "branch": null,
+          "revision": "9ff1cc9327586db4e0c8f46f064b6a82ec1566fa",
+          "version": "4.0.6"
+        }
       }
-    },
-    {
-      "identity" : "service-model-swift-code-generate",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/amzn/service-model-swift-code-generate.git",
-      "state" : {
-        "revision" : "cf4aa31478c296f3afeafffdbe14ae5bfbc99593",
-        "version" : "3.0.0-beta.11"
-      }
-    },
-    {
-      "identity" : "smoke-aws-generate",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/amzn/smoke-aws-generate.git",
-      "state" : {
-        "revision" : "fc01b7d4a0222df636a1a9ff8827a0159fef52bd",
-        "version" : "3.0.0-beta.7"
-      }
-    },
-    {
-      "identity" : "swaggerparser",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/tachyonics/SwaggerParser.git",
-      "state" : {
-        "revision" : "c0eb70485c59a9d7dd6765dcd303b49fdb3040ee",
-        "version" : "0.6.4"
-      }
-    },
-    {
-      "identity" : "swift-argument-parser",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-argument-parser",
-      "state" : {
-        "revision" : "6b2aa2748a7881eebb9f84fb10c01293e15b52ca",
-        "version" : "0.5.0"
-      }
-    },
-    {
-      "identity" : "yams",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/jpsim/Yams.git",
-      "state" : {
-        "revision" : "9ff1cc9327586db4e0c8f46f064b6a82ec1566fa",
-        "version" : "4.0.6"
-      }
-    }
-  ],
-  "version" : 2
+    ]
+  },
+  "version": 1
 }

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,61 +1,59 @@
 {
-  "object": {
-    "pins": [
-      {
-        "package": "OpenAPIKit",
-        "repositoryURL": "https://github.com/mattpolzin/OpenAPIKit.git",
-        "state": {
-          "branch": null,
-          "revision": "0c668112f9803c1858ed070f9e8ce84922a0b41f",
-          "version": "3.0.0-alpha.4"
-        }
-      },
-      {
-        "package": "ServiceModelSwiftCodeGenerate",
-        "repositoryURL": "https://github.com/amzn/service-model-swift-code-generate.git",
-        "state": {
-          "branch": null,
-          "revision": "4c0ccda7df61c87538df34fc47982435c4a52206",
-          "version": "3.0.0-beta.5"
-        }
-      },
-      {
-        "package": "SmokeAWSGenerate",
-        "repositoryURL": "https://github.com/amzn/smoke-aws-generate.git",
-        "state": {
-          "branch": null,
-          "revision": "d71519da40a2058ea2188f35a7cbd3082534a97e",
-          "version": "3.0.0-beta.3"
-        }
-      },
-      {
-        "package": "SwaggerParser",
-        "repositoryURL": "https://github.com/tachyonics/SwaggerParser.git",
-        "state": {
-          "branch": null,
-          "revision": "c0eb70485c59a9d7dd6765dcd303b49fdb3040ee",
-          "version": "0.6.4"
-        }
-      },
-      {
-        "package": "swift-argument-parser",
-        "repositoryURL": "https://github.com/apple/swift-argument-parser",
-        "state": {
-          "branch": null,
-          "revision": "6b2aa2748a7881eebb9f84fb10c01293e15b52ca",
-          "version": "0.5.0"
-        }
-      },
-      {
-        "package": "Yams",
-        "repositoryURL": "https://github.com/jpsim/Yams.git",
-        "state": {
-          "branch": null,
-          "revision": "9ff1cc9327586db4e0c8f46f064b6a82ec1566fa",
-          "version": "4.0.6"
-        }
+  "pins" : [
+    {
+      "identity" : "openapikit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/mattpolzin/OpenAPIKit.git",
+      "state" : {
+        "revision" : "0c668112f9803c1858ed070f9e8ce84922a0b41f",
+        "version" : "3.0.0-alpha.4"
       }
-    ]
-  },
-  "version": 1
+    },
+    {
+      "identity" : "service-model-swift-code-generate",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/amzn/service-model-swift-code-generate.git",
+      "state" : {
+        "revision" : "cf4aa31478c296f3afeafffdbe14ae5bfbc99593",
+        "version" : "3.0.0-beta.11"
+      }
+    },
+    {
+      "identity" : "smoke-aws-generate",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/amzn/smoke-aws-generate.git",
+      "state" : {
+        "revision" : "fc01b7d4a0222df636a1a9ff8827a0159fef52bd",
+        "version" : "3.0.0-beta.7"
+      }
+    },
+    {
+      "identity" : "swaggerparser",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/tachyonics/SwaggerParser.git",
+      "state" : {
+        "revision" : "c0eb70485c59a9d7dd6765dcd303b49fdb3040ee",
+        "version" : "0.6.4"
+      }
+    },
+    {
+      "identity" : "swift-argument-parser",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-argument-parser",
+      "state" : {
+        "revision" : "6b2aa2748a7881eebb9f84fb10c01293e15b52ca",
+        "version" : "0.5.0"
+      }
+    },
+    {
+      "identity" : "yams",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/jpsim/Yams.git",
+      "state" : {
+        "revision" : "9ff1cc9327586db4e0c8f46f064b6a82ec1566fa",
+        "version" : "4.0.6"
+      }
+    }
+  ],
+  "version" : 2
 }

--- a/Package.swift
+++ b/Package.swift
@@ -38,8 +38,8 @@ let package = Package(
             targets: ["SmokeFrameworkGenerateHttp1"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/amzn/smoke-aws-generate.git", from: "3.0.0-beta.3"),
-        .package(url: "https://github.com/amzn/service-model-swift-code-generate.git", from: "3.0.0-beta.5"),
+        .package(url: "https://github.com/amzn/smoke-aws-generate.git", from: "3.0.0-beta.5"),
+        .package(url: "https://github.com/amzn/service-model-swift-code-generate.git", from: "3.0.0-beta.10"),
         .package(url: "https://github.com/apple/swift-argument-parser", from: "0.3.0"),
     ],
     targets: [

--- a/Package@swift-5.4.swift
+++ b/Package@swift-5.4.swift
@@ -30,9 +30,9 @@ let package = Package(
     ],
     dependencies: [
         .package(name: "SmokeAWSGenerate",
-                 url: "https://github.com/amzn/smoke-aws-generate.git", from: "3.0.0-beta.3"),
+                 url: "https://github.com/amzn/smoke-aws-generate.git", from: "3.0.0-beta.5"),
         .package(name: "ServiceModelSwiftCodeGenerate",
-                 url: "https://github.com/amzn/service-model-swift-code-generate.git", from: "3.0.0-beta.5"),
+                 url: "https://github.com/amzn/service-model-swift-code-generate.git", from: "3.0.0-beta.10"),
         .package(url: "https://github.com/apple/swift-argument-parser", from: "0.3.0"),
     ],
     targets: [

--- a/Package@swift-5.5.swift
+++ b/Package@swift-5.5.swift
@@ -30,9 +30,9 @@ let package = Package(
     ],
     dependencies: [
         .package(name: "SmokeAWSGenerate",
-                 url: "https://github.com/amzn/smoke-aws-generate.git", from: "3.0.0-beta.3"),
+                 url: "https://github.com/amzn/smoke-aws-generate.git", from: "3.0.0-beta.4"),
         .package(name: "ServiceModelSwiftCodeGenerate",
-                 url: "https://github.com/amzn/service-model-swift-code-generate.git", from: "3.0.0-beta.5"),
+                 url: "https://github.com/amzn/service-model-swift-code-generate.git", from: "3.0.0-beta.10"),
         .package(url: "https://github.com/apple/swift-argument-parser", from: "0.3.0"),
     ],
     targets: [


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Update the dependencies, mainly `smoke-aws-generate` to include a bug [fix](https://github.com/amzn/smoke-aws-generate/commit/1ec9e345238c9241000d09879515b6f283d207de) to the Client Generators not using the generic client name

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
