### PR TITLE
Fix issue with trace context type.

### DIFF
--- a/Sources/SmokeFrameworkCodeGeneration/SmokeFrameworkCodeGeneration.swift
+++ b/Sources/SmokeFrameworkCodeGeneration/SmokeFrameworkCodeGeneration.swift
@@ -287,11 +287,11 @@ extension ServiceModelCodeGenerator where TargetSupportType: ModelTargetSupport 
                 generatorFileType = .clientGenerator
             }
             
-            generateAWSClient(delegate: clientProtocolDelegate, fileType: .clientImplementation)
-            generateAWSClient(delegate: mockClientDelegate, fileType: .clientImplementation)
-            generateAWSClient(delegate: throwingClientDelegate, fileType: .clientImplementation)
-            generateAWSClient(delegate: awsClientDelegate, fileType: .clientImplementation)
-            generateAWSClient(delegate: awsClientDelegate, fileType: generatorFileType)
+            generateSmokeFrameworkClient(delegate: clientProtocolDelegate, fileType: .clientImplementation)
+            generateSmokeFrameworkClient(delegate: mockClientDelegate, fileType: .clientImplementation)
+            generateSmokeFrameworkClient(delegate: throwingClientDelegate, fileType: .clientImplementation)
+            generateSmokeFrameworkClient(delegate: awsClientDelegate, fileType: .clientImplementation)
+            generateSmokeFrameworkClient(delegate: awsClientDelegate, fileType: generatorFileType)
             generateAWSOperationsReporting()
             generateAWSInvocationsReporting()
             generateModelOperationClientInput()
@@ -334,6 +334,13 @@ extension ServiceModelCodeGenerator where TargetSupportType: ModelTargetSupport 
                                      plugin: "SmokeFrameworkGenerateHttp1",
                                      generationType: generationType)
         }
+    }
+    
+    private func generateSmokeFrameworkClient<DelegateType: ModelClientDelegate>(delegate: DelegateType, fileType: ClientFileType)
+    where DelegateType.TargetSupportType == TargetSupportType, DelegateType.ModelType == ModelType {
+        let defaultTraceContextType = DefaultTraceContextType(typeName: "SmokeInvocationTraceContext",
+                                                              importTargetName: "SmokeOperationsHTTP1")
+        generateClient(delegate: delegate, fileType: fileType, defaultTraceContextType: defaultTraceContextType)
     }
 
     // Due to a current limitation of the SPM plugins for code generators, a placeholder Swift file


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Provides the correct trace context to the code generator. Fixes an issue where the client couldn't be directly instantiated using its non-generic type alias.

```
let client = APIGatewayTheClient(
                credentialsProvider: credentialsProvider,
                awsRegion: awsRegion,
                endpointHostName: endpointHostName,
                stage: stage,
                eventLoopProvider: eventLoopProvider)
        }
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
