### PR TITLE
Update SwaggerParser repository location because original is 404

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/amzn/openapi-swift-code-generate.git",
       "state" : {
-        "revision" : "9ac750f50061f9046d6dbdf71fe064234f4ed099",
-        "version" : "1.0.1"
+        "revision" : "2785b1dd472850c470b5cd3c9b727ce3dff4827d",
+        "version" : "1.0.3"
       }
     },
     {
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/mattpolzin/OpenAPIKit.git",
       "state" : {
-        "revision" : "d40e6c3d57b1b27ac2114861d5a83cf8ee9d206d",
-        "version" : "3.0.0-alpha.6"
+        "revision" : "33a9984b4af03f00e68b8ee85f1273cb826af04f",
+        "version" : "3.1.3"
       }
     },
     {
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/amzn/service-model-swift-code-generate.git",
       "state" : {
-        "revision" : "b9d45b4d05196c26247d4bd3aca83c1e53eed72c",
-        "version" : "3.0.2"
+        "revision" : "4e9ffec2cfc53c49aedae96aa16587f9f7b88c38",
+        "version" : "3.1.1"
       }
     },
     {
@@ -32,14 +32,14 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/amzn/smoke-aws-generate.git",
       "state" : {
-        "revision" : "8f0eae3b4afd9f5e586d6fcf6c9f1c171923a83d",
-        "version" : "3.0.0"
+        "revision" : "bbb08b2d148372cf16b003a56d1f99d522dd70ea",
+        "version" : "3.2.1"
       }
     },
     {
       "identity" : "swaggerparser",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/tachyonics/SwaggerParser.git",
+      "location" : "https://github.com/knovichikhin/SwaggerParser.git",
       "state" : {
         "revision" : "c0eb70485c59a9d7dd6765dcd303b49fdb3040ee",
         "version" : "0.6.4"
@@ -50,8 +50,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-argument-parser",
       "state" : {
-        "revision" : "fee6933f37fde9a5e12a1e4aeaa93fe60116ff2a",
-        "version" : "1.2.2"
+        "revision" : "0fbc8848e389af3bb55c182bc19ca9d5dc2f255b",
+        "version" : "1.4.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -40,7 +40,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/amzn/smoke-aws-generate.git", from: "3.0.0"),
         .package(url: "https://github.com/amzn/service-model-swift-code-generate.git", from: "3.0.0"),
-        .package(url: "https://github.com/amzn/openapi-swift-code-generate.git", from: "1.0.0"),
+        .package(url: "https://github.com/amzn/openapi-swift-code-generate.git", from: "1.0.3"),
         .package(url: "https://github.com/apple/swift-argument-parser", from: "1.0.0"),
     ],
     targets: [


### PR DESCRIPTION
*Issue #, if available:*
Update SwaggerParser repository location because original is 404

*Description of changes:*
Update to forked SwaggerParse via `openapi-swift-code-generate`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
